### PR TITLE
Ignore .vscode and add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,9 @@ yarn-error.log
 .yarn-integrity
 
 .netlify/
+
+# Editors
+.vscode/*
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json


### PR DESCRIPTION
Hope the changes are clear. The `.vscode` files that are not ignored are files that could be used for meaningful automation.