### PR TITLE
[Feature] Ability to author posts without required hero

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby/data/data.normalize.js
+++ b/@narative/gatsby-theme-novela/gatsby/data/data.normalize.js
@@ -1,23 +1,63 @@
+/**
+ * In order to improve the authoring experience we'll set a fallback for hero images
+ * when they're not provided. This will allow you to write articles without immediately
+ * adding a hero image.
+ *
+ * @param {Object} heroSource
+ */
+function normalizeHero(article) {
+  let hero = {
+    full: {},
+    regular: {},
+    narrow: {},
+    seo: {},
+  };
+
+  if (article.hero) {
+    hero = {
+      full: article.hero.full.fluid,
+      regular: article.hero.regular.fluid,
+      narrow: article.hero.narrow.fluid,
+      seo: article.hero.seo.fixed,
+    };
+  } else {
+    console.log("\x1b[33m", `Missing hero for "${article.title}"`);
+  }
+
+  return hero;
+}
+
+function normalizeAvatar(author) {
+  let avatar = {
+    small: {},
+    medium: {},
+    large: {},
+  };
+
+  if (author.avatar) {
+    avatar = {
+      small: author.avatar.small.fluid,
+      medium: author.avatar.medium.fluid,
+      large: author.avatar.large.fluid,
+    };
+  } else {
+    console.log("\x1b[33m", `Missing avatar for "${author.name}"`);
+  }
+
+  return avatar;
+}
+
 module.exports.local = {
   articles: ({ node: article }) => {
     return {
       ...article,
-      hero: {
-        full: article.hero.full.fluid,
-        regular: article.hero.regular.fluid,
-        narrow: article.hero.narrow.fluid,
-        seo: article.hero.seo.fixed,
-      },
+      hero: normalizeHero(article),
     };
   },
   authors: ({ node: author }) => {
     return {
       ...author,
-      avatar: {
-        small: author.avatar.small.fluid,
-        medium: author.avatar.medium.fluid,
-        large: author.avatar.large.fluid,
-      },
+      avatar: normalizeAvatar(author),
     };
   },
 };

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Hero.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Hero.tsx
@@ -16,10 +16,12 @@ interface ArticleHeroProps {
 
 const ArticleHero = ({ article, authors }: ArticleHeroProps) => {
   const hasCoAUthors = authors.length > 1;
+  const hasHeroImage =
+    Object.keys(article.hero.full).length !== 0 && article.hero.full.constructor === Object;
 
   return (
     <Hero>
-      <Header>
+      <Header hasHeroImage={hasHeroImage}>
         <HeroHeading>{article.title}</HeroHeading>
         <HeroSubtitle hasCoAUthors={hasCoAUthors}>
           <ArticleAuthors authors={authors} />
@@ -73,10 +75,10 @@ const ArticleMeta = styled.div<{ hasCoAUthors: boolean }>`
   `}
 `;
 
-const Header = styled.header`
+const Header = styled.header<{ hasHeroImage: boolean }>`
   position: relative;
   z-index: 10;
-  margin: 100px auto 120px;
+  margin: ${p => (p.hasHeroImage ? "100px auto 120px" : "100px auto 0px")};
   padding-left: 68px;
   max-width: 749px;
 
@@ -160,8 +162,7 @@ const HeroImage = styled.div`
   max-height: 424px;
   max-width: 944px;
   margin: 0 auto;
-  box-shadow: 0 30px 60px -10px rgba(0, 0, 0, 0.2),
-    0 18px 36px -18px rgba(0, 0, 0, 0.22);
+  box-shadow: 0 30px 60px -10px rgba(0, 0, 0, 0.2), 0 18px 36px -18px rgba(0, 0, 0, 0.22);
 
   ${mediaqueries.tablet`
     max-width: 100%;


### PR DESCRIPTION
solves: https://github.com/narative/gatsby-theme-novela/issues/61

When authoring, you don't want to have a hero image right away. Therefore, we should allow initial authoring to work without a defined image.

Implementation adds a warning into command line:
<img width="474" alt="Screen Shot 2019-08-14 at 9 21 34 am" src="https://user-images.githubusercontent.com/8007686/63037933-f3f64e80-be74-11e9-8091-4f823f693d19.png">

Site continues to run without issues. Articles list has missing hero image and Article page displays no hero.