### PR TITLE
added theme-ui font sansSerif to Paragraph

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/Paragraph/Paragraph.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Paragraph/Paragraph.tsx
@@ -5,6 +5,7 @@ const Paragraph = styled.p`
   line-height: 1.756;
   font-size: 18px;
   color: ${p => p.theme.colors.articleText};
+  font-family: ${p => p.theme.fonts.sansSerif};
   transition: ${p => p.theme.colorModeTransition};
   margin: 0 auto 35px;
   width: 100%;

--- a/@narative/gatsby-theme-novela/src/gatsby-plugin-theme-ui/index.ts
+++ b/@narative/gatsby-theme-novela/src/gatsby-plugin-theme-ui/index.ts
@@ -10,14 +10,13 @@ const breakpoints = [
   ["tablet", 735],
   ["desktop", 1070],
   ["desktop_medium", 1280],
-  ["desktop_large", 1440],
+  ["desktop_large", 1440]
 ];
 
 const fonts = {
   serif: "'Merriweather', Georgia, Serif",
-  sansSerif:
-    "'SF Pro Display', '-apple-system', 'BlinkMacSystemFont', 'San Francisco', 'Helvetica Neue', 'Helvetica', 'Ubuntu', 'Roboto', 'Noto', 'Segoe UI', 'Arial', sans-serif",
-  monospace: `"Operator Mono", Consolas, Menlo, Monaco, source-code-pro, Courier New, monospace`,
+  sansSerif: "'Ubuntu', 'Roboto', 'Noto', 'Segoe UI', 'Arial', sans-serif",
+  monospace: `"Operator Mono", Consolas, Menlo, Monaco, source-code-pro, Courier New, monospace`
 };
 
 const colorModeTransition =
@@ -29,5 +28,5 @@ export default merge({
   colors,
   fonts,
   breakpoints,
-  tags,
+  tags
 });

--- a/@narative/gatsby-theme-novela/src/gatsby-plugin-theme-ui/index.ts
+++ b/@narative/gatsby-theme-novela/src/gatsby-plugin-theme-ui/index.ts
@@ -15,7 +15,8 @@ const breakpoints = [
 
 const fonts = {
   serif: "'Merriweather', Georgia, Serif",
-  sansSerif: "'Ubuntu', 'Roboto', 'Noto', 'Segoe UI', 'Arial', sans-serif",
+  sansSerif:
+    "'SF Pro Display', '-apple-system', 'BlinkMacSystemFont', 'San Francisco', 'Helvetica Neue', 'Helvetica', 'Ubuntu', 'Roboto', 'Noto', 'Segoe UI', 'Arial', sans-serif",
   monospace: `"Operator Mono", Consolas, Menlo, Monaco, source-code-pro, Courier New, monospace`
 };
 


### PR DESCRIPTION
The body fonts were being set in the global styles file and weren't taking into account the sansSerif defined in theme-ui. I added this line so that fonts can be over-ridden from here. I labeled this as hotfix because I guess it was the original intention? 