### PR TITLE
Make unhandled social media url more explicit

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/SocialLinks/SocialLinks.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SocialLinks/SocialLinks.tsx
@@ -36,7 +36,9 @@ function SocialLinks({ links, fill = "#73737D" }: SocialLinksProps) {
       {links.map(option => {
         const name = getHostname(option.url);
         const Icon = icons[name];
-
+        if (!Icon) {
+          throw new Error(`unsupported social link name=${name} / url=${option.url}`);
+        }
         return (
           <SocialIconContainer
             key={option.url}


### PR DESCRIPTION
Got this obscure error after upgrading, because I had a stackoverflow link to my author profile, and it took some time to figure out what was the reason

![Uploading image.png…]()
