### PR TITLE
Fixes subscription panel fade when having only one post.

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/Subscription/Subscription.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Subscription/Subscription.tsx
@@ -85,6 +85,7 @@ const SubscriptionContainer = styled.div`
   margin: 10px auto 100px;
   background: ${p => p.theme.colors.card};
   box-shadow: 0px 4px 50px rgba(0, 0, 0, 0.05);
+  z-index: 1;
 
   ${mediaqueries.tablet`
     padding: 50px 0 0;


### PR DESCRIPTION
This is a small fix which I would not have noticed if I hadn't had only one post.

Before the fix when you had only one post:

![Screenshot_2019-08-27 Getting started with Novela](https://user-images.githubusercontent.com/1839930/63763712-8e1eb380-c8c5-11e9-91a9-75a6fd2e4156.png)

After the fix with one post:

![Screenshot_2019-08-27 Getting started with Novela(1)](https://user-images.githubusercontent.com/1839930/63763728-95de5800-c8c5-11e9-89c2-2d08c186951a.png)
