### PR TITLE
More articles no longer displays secret articles

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby/node/createPages.js
+++ b/@narative/gatsby-theme-novela/gatsby/node/createPages.js
@@ -187,7 +187,7 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
      * We need a way to find the next artiles to suggest at the bottom of the articles page.
      * To accomplish this there is some special logic surrounding what to show next.
      */
-    let next = articles.slice(index + 1, index + 3);
+    let next = articles.filter(article => !article.secret).slice(index + 1, index + 3);
     // If it's the last item in the list, there will be no articles. So grab the first 2
     if (next.length === 0) next = articles.slice(0, 2);
     // If there's 1 item in the list, grab the first article


### PR DESCRIPTION
This PR applies a filter to the articles that are displayed at the bottom of the article page in more articles (next) section, preventing secret articles from showing there.

Related to Issue #63 