### PR TITLE
[Feature] Custom permalink for articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,16 +505,17 @@ You will want to override it here:
 
 It is recommended to use the Default options, but if your project requires something else you can configure them to your need.
 
-| Option             |     Default     |                                        Description                                        |
-| ------------------ | :-------------: | :---------------------------------------------------------------------------------------: |
-| contentPosts       |  content/posts  |                     Define where you want to pull your Post data from                     |
-| contentAuthors     | content/authors |                    Define where you want to pull your Author data from                    |
-| authorsPage        |      false      |                                    Create Author pages                                    |
-| authorsPath        |    /authors     |                              Where should Author pages live?                              |
-| basePath           |        /        | Where should the site be served from? `/blog` will change all paths to start with `/blog` |
-| mailchimp          |      false      |                        Enable Mailchimp subscriptions on each Post                        |
-| sources.local      |      true       |                           Enable local file system data source                            |
-| sources.contentful |      false      |                               Enable Contentful data source                               |
+| Option                 |     Default     |                                                             Description                                                             |
+| ---------------------- | :-------------: | :---------------------------------------------------------------------------------------------------------------------------------: |
+| contentPosts           |  content/posts  |                                          Define where you want to pull your Post data from                                          |
+| contentAuthors         | content/authors |                                         Define where you want to pull your Author data from                                         |
+| authorsPage            |      false      |                                                         Create Author pages                                                         |
+| authorsPath            |    /authors     |                                                   Where should Author pages live?                                                   |
+| basePath               |        /        |                      Where should the site be served from? `/blog` will change all paths to start with `/blog`                      |
+| articlePermalinkFormat |      :slug      | Define the format of the article permalink. Possible values: `:slug`, `:year`, `:month`, `:day`. Example: `:year/:month/:day/:slug` |
+| mailchimp              |      false      |                                             Enable Mailchimp subscriptions on each Post                                             |
+| sources.local          |      true       |                                                Enable local file system data source                                                 |
+| sources.contentful     |      false      |                                                    Enable Contentful data source                                                    |
 
 [View Theme option example](https://github.com/narative/gatsby-theme-novela-example/blob/master/gatsby-config.js#L36)
 


### PR DESCRIPTION
This PR adds the ability to change articles URL format.

By default, it doesn't change anything (except slug format for author page but it's described below).

You can add `articlePermalinkFormat: ":year/:month/:day/:slug"` to theme options to change the article URL to `/2019/01/01/my-article`. It works also with `basePath` (`/base/2019/01/01/my-article`).

I think I've fixed one bug. Let's say that I have `basePath` set to `/blog`. Currently (in the master branch), it generates author URL as `/authors/blog/dennis-brotzky` which is not correct, is it? Now, the `basePath` is at the beginning, `/blog/authors/dennis-brotzky`.

I hope we can add this feature to the theme because it's one of the changes I need to be able to migrate my blog 😉 
