### PR TITLE
[Fix] Large image width

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/MDX/MDX.tsx
+++ b/@narative/gatsby-theme-novela/src/components/MDX/MDX.tsx
@@ -62,7 +62,7 @@ export default MDX;
 const IMAGE_WIDTHS = {
   regular: "680px",
   large: "1004px",
-  full: "100%"
+  full: "100vw"
 };
 
 const ARTICLE_WIDTH = css`
@@ -287,7 +287,6 @@ const ImageCSS = css`
     position: relative;
     left: -68px;
     width: ${IMAGE_WIDTHS.full};
-    max-width: ${IMAGE_WIDTHS.full};
     margin: 25px auto 60px;
     pointer-events: none;
 


### PR DESCRIPTION
Quick fix to make the large image width the same as window width.

Look at the example site, https://novela.narative.co/understanding-the-gatsby-lifecycle-with-narative. The large image has a margin on the right side.

Preview: https://deploy-preview-112--gatsby-theme-novela.netlify.com/understanding-the-gatsby-lifecycle-with-narative