### PR TITLE
Fix for secret articles in next section and RSS feed

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-config.js
+++ b/@narative/gatsby-theme-novela/gatsby-config.js
@@ -34,27 +34,31 @@ module.exports = ({
           },
           ...rest
         }) => {
-          siteMetadata.feed_url = siteMetadata.siteUrl + '/rss.xml';
-          siteMetadata.image_url = siteMetadata.siteUrl + '/icons/icon-512x512.png';
+          const siteMetadataModified = siteMetadata;
+          siteMetadataModified.feed_url = `${siteMetadata.siteUrl}/rss.xml`;
+          siteMetadataModified.image_url = `${siteMetadata.siteUrl}/icons/icon-512x512.png`;
 
           return {
-            ...siteMetadata,
+            ...siteMetadataModified,
             ...rest,
-          }
+          };
         },
         feeds: [
           {
             serialize: ({ query: { site, allArticle } }) => {
-              return allArticle.edges.map(edge => {
-                return Object.assign({}, edge.node, {
-                  description: edge.node.excerpt,
-                  date: edge.node.date,
-                  url: site.siteMetadata.siteUrl + edge.node.slug,
-                  guid: site.siteMetadata.siteUrl + edge.node.slug,
-                  // custom_elements: [{ "content:encoded": edge.node.body }],
-                  author: edge.node.author
-                })
-              })
+              return allArticle.edges
+                .filter(edge => !edge.node.secret)
+                .map(edge => {
+                  return {
+                    ...edge.node,
+                    description: edge.node.excerpt,
+                    date: edge.node.date,
+                    url: site.siteMetadata.siteUrl + edge.node.slug,
+                    guid: site.siteMetadata.siteUrl + edge.node.slug,
+                    // custom_elements: [{ "content:encoded": edge.node.body }],
+                    author: edge.node.author,
+                  };
+                });
             },
             query: `
               {
@@ -66,12 +70,13 @@ module.exports = ({
                       slug
                       title
                       author
+                      secret
                     }
                   }
                 }
               }
             `,
-            output: "/rss.xml"
+            output: '/rss.xml',
           },
         ],
       },

--- a/@narative/gatsby-theme-novela/gatsby/node/createPages.js
+++ b/@narative/gatsby-theme-novela/gatsby/node/createPages.js
@@ -188,15 +188,13 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
      * We need a way to find the next artiles to suggest at the bottom of the articles page.
      * To accomplish this there is some special logic surrounding what to show next.
      */
-    let next = articles
-      .filter(article => !article.secret)
-      .slice(index + 1, index + 3);
+    let next = articlesThatArentSecret.slice(index + 1, index + 3);
     // If it's the last item in the list, there will be no articles. So grab the first 2
-    if (next.length === 0) next = articles.slice(0, 2);
+    if (next.length === 0) next = articlesThatArentSecret.slice(0, 2);
     // If there's 1 item in the list, grab the first article
-    if (next.length === 1 && articles.length !== 2)
-      next = [...next, articles[0]];
-    if (articles.length === 1) next = [];
+    if (next.length === 1 && articlesThatArentSecret.length !== 2)
+      next = [...next, articlesThatArentSecret[0]];
+    if (articlesThatArentSecret.length === 1) next = [];
 
     createPage({
       path: article.slug,
@@ -222,11 +220,10 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
     log('Creating', 'authors page');
 
     authors.forEach(author => {
-      const articlesTheAuthorHasWritten = articles
-        .filter(article =>
+      const articlesTheAuthorHasWritten = articlesThatArentSecret.filter(
+        article =>
           article.author.toLowerCase().includes(author.name.toLowerCase()),
-        )
-        .filter(article => !article.secret);
+      );
       const path = slugify(author.slug, authorsPath);
 
       createPaginatedPages({


### PR DESCRIPTION
This PR prevents showing secret articles in the next section at the bottom of a post. See here for more details https://github.com/narative/gatsby-theme-novela/issues/63#issuecomment-526125243 Related to this PR https://github.com/narative/gatsby-theme-novela/pull/103

I've also added code to prevent showing secret articles in the RSS feed.

btw. The new lint system is great! Got it under control now.