### PR TITLE
[Fix] Dark theme blinks on refresh

### DIFF
--- a/@narative/gatsby-theme-novela/package.json
+++ b/@narative/gatsby-theme-novela/package.json
@@ -51,7 +51,7 @@
     "gatsby-plugin-mdx": "^1.0.32",
     "gatsby-plugin-react-helmet": "^3.1.2",
     "gatsby-plugin-sharp": "^2.2.9",
-    "gatsby-plugin-theme-ui": "^0.2.34",
+    "gatsby-plugin-theme-ui": "^0.2.38",
     "gatsby-plugin-typescript": "^2.1.2",
     "gatsby-remark-autolink-headers": "^2.1.3",
     "gatsby-remark-check-links": "^1.1.5",
@@ -74,7 +74,7 @@
     "react-outside-click-handler": "^1.2.4",
     "remark-slug": "^5.1.2",
     "request": "^2.88.0",
-    "theme-ui": "^0.2.21",
+    "theme-ui": "^0.2.38",
     "typeface-merriweather": "^0.0.72"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6168,10 +6168,10 @@ gatsby-plugin-sharp@^2.2.9:
     sharp "^0.22.1"
     svgo "^1.2.0"
 
-gatsby-plugin-theme-ui@^0.2.34:
-  version "0.2.34"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-theme-ui/-/gatsby-plugin-theme-ui-0.2.34.tgz#bbc5af48849ff4be88cd9ef6b66439768da80966"
-  integrity sha512-y9QrtMEhalB1mJ7E0y8UW9sffrTJ4W/dj0631k0LfUxEeKs2gA3VJf4yuJ+MOu4RloE9XDC04csM6zOy0tz7kA==
+gatsby-plugin-theme-ui@^0.2.38:
+  version "0.2.38"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-theme-ui/-/gatsby-plugin-theme-ui-0.2.38.tgz#519afdd63ffe4cf3824f1150a933f2ff57b549b3"
+  integrity sha512-4HUf5EoYQAuxrSyLRVyrYNzqOVnj4hNuPorQk55l8kvTR1MdL3URaoQmsES895cb6+mNOb4/ODb66tFCOdwjwQ==
 
 gatsby-plugin-typescript@^2.1.2:
   version "2.1.2"
@@ -13602,10 +13602,10 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-theme-ui@^0.2.21:
-  version "0.2.35"
-  resolved "https://registry.yarnpkg.com/theme-ui/-/theme-ui-0.2.35.tgz#6f953086878e2746298f38272e8cbb6344d3acff"
-  integrity sha512-NJJEtnLogIULuwL/dF15kfv+97ZR/rWFLccrR60iGCj6j8hk4krqO+g573hV4bowDorCFPA4yQb0HHZbm+1P1g==
+theme-ui@^0.2.38:
+  version "0.2.38"
+  resolved "https://registry.yarnpkg.com/theme-ui/-/theme-ui-0.2.38.tgz#7d294b6bf8b5bae27e36cccb41c0eca60309f0c9"
+  integrity sha512-nPjZlDyRISPu1EYlYHOUT5IKFd22cSEg3i2Kr9EH/mbtD3ezTAqAdE7SKzjUe9tFyagJ9y0UbY/tUI+SENu8wQ==
   dependencies:
     "@emotion/is-prop-valid" "^0.8.1"
     "@styled-system/css" "^5.0.16"


### PR DESCRIPTION
Upgrading `theme-ui` and `gatsby-plugin-theme-ui` fixed problems in refreshing page with dark theme.

Fix #85 