### PR TITLE
Fixes article seo structured data

### DIFF
--- a/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
@@ -3,6 +3,22 @@ import React from "react";
 import SEO from "@components/SEO";
 
 import { IArticle, IAuthor } from "@types";
+import { graphql, useStaticQuery } from "gatsby";
+
+const siteQuery = graphql`
+  {
+    allSite {
+      edges {
+        node {
+          siteMetadata {
+            name
+            siteUrl
+          }
+        }
+      }
+    }
+  }
+`;
 
 function ArticleSEO({
   article,
@@ -13,25 +29,52 @@ function ArticleSEO({
   authors: IAuthor[];
   location: any;
 }) {
+  const results = useStaticQuery(siteQuery);
+  const name = results.allSite.edges[0].node.siteMetadata.name;
+  const siteUrl = results.allSite.edges[0].node.siteMetadata.siteUrl;
+
   const authorsData = authors.map(author => ({
     "@type": "Person",
     name: author.name,
   }));
 
-  const microdata = `{
+  /**
+   * For some reason `location.href` is undefined here when using `yarn build`.
+   * That is why I am using static query `allSite` to get needed fields: name & siteUrl.
+   */
+  let microdata = `{
     "@context": "https://schema.org",
     "@type": "Article",
     "mainEntityOfPage": {
       "@type": "WebPage",
-      "@id": "${location.href}"
+      "@id": "${siteUrl + location.pathname}"
     },
     "headline": "${article.title}",
-    "image": "${article.hero.seo.src}",
+    "image": "${siteUrl + article.hero.seo.src}",
     "datePublished": "${article.dateForSEO}",
-    "author": ${authorsData},
-    "description": "${article.excerpt.replace(/"/g, '\\"')}"
+    "dateModified": "${article.dateForSEO}",
+    "author": ${JSON.stringify(authorsData)},
+    "description": "${article.excerpt.replace(/"/g, '\\"')}",
+    "publisher": {
+      "@type": "Organization",
+      "name": "${name}",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "${siteUrl}/icons/icon-512x512.png"
+      }
+    }
   }
-`.replace(/\s/g, "");
+`.replace(/"[^"]+"|(\s)/gm, function(matched, group1) {
+  if (!group1) {
+    return matched;
+  } else {
+    return "";
+  }
+});
+/**
+ * See here for the explanation of the regex above:
+ * https://stackoverflow.com/a/23667311
+ */
 
   return (
     <SEO


### PR DESCRIPTION
Fixes issue #127 

Additional fixes:
- adds `publisher` field which is required by google
- modified regex to remove whitespace inside `microdata` but not within strings enclosed with `"`. This allows the `microdata` to be stripped of white spaces while still preserving description, headline and author name white spaces.
- prepended image with `siteUrl`
- `location.href` is `undefined` when running `yarn build` causing:

```
"mainEntityOfPage":{"@type":"WebPage","@id":"undefined"}
```

To solve this I have added a static query to fetch the site name (used in `publisher`) & siteUrl which I applied to appropriate places.

You can view the [current state of structured data of Novela here](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fnovela.narative.co%2Funderstanding-the-gatsby-lifecycle-with-narative)

You can view [the state of structured data on my blog with this PR](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fblog.laravelista.hr%2F2019%2F08%2F27%2Fgetting-started-with-novela)