### PR TITLE
fix: assign `sources` a default value in gatsby-config export

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-config.js
+++ b/@narative/gatsby-theme-novela/gatsby-config.js
@@ -3,7 +3,7 @@
 module.exports = ({
   contentAuthors = 'content/authors',
   contentPosts = 'content/posts',
-  sources: { local, contentful },
+  sources: { local, contentful } = { local: true, contentful: false },
 }) => ({
   mapping: {
     'Mdx.frontmatter.author': `AuthorsYaml`,


### PR DESCRIPTION
Fixes #141