### PR TITLE
refactor(gatsby-config): pass on pathPrefix

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-config.js
+++ b/@narative/gatsby-theme-novela/gatsby-config.js
@@ -3,8 +3,10 @@
 module.exports = ({
   contentAuthors = 'content/authors',
   contentPosts = 'content/posts',
+  pathPrefix = '',
   sources: { local, contentful } = { local: true, contentful: false },
 }) => ({
+  pathPrefix,
   mapping: {
     'Mdx.frontmatter.author': `AuthorsYaml`,
   },


### PR DESCRIPTION
Not sure if it's a gatsby bug or not, but if I set `pathPrefix` on the top level, meaning when Novela is used as a plugin, then `pathPrefix` is not picked up.