### PR TITLE
chore(gatsby-node): fix typo in createPages hook

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby/node/createPages.js
+++ b/@narative/gatsby-theme-novela/gatsby/node/createPages.js
@@ -73,7 +73,7 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
 
   if (local) {
     try {
-      log('Querying Authors & Aritcles source:', 'Local');
+      log('Querying Authors & Articles source:', 'Local');
       const localAuthors = await graphql(query.local.authors);
       const localArticles = await graphql(query.local.articles);
 
@@ -91,7 +91,7 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
 
   if (contentful) {
     try {
-      log('Querying Authors & Aritcles source:', 'Contentful');
+      log('Querying Authors & Articles source:', 'Contentful');
       const contentfulAuthors = await graphql(query.contentful.authors);
       const contentfulArticles = await graphql(query.contentful.articles);
 


### PR DESCRIPTION
This PR just fixes a typo in the `createPages` hook logger.

From:

```javascript
log('Querying Authors & Aritcles source:', 'Local');
```

![Screen Shot 2019-10-06 at 7 17 42 PM](https://user-images.githubusercontent.com/3136873/66278480-f5d60000-e86e-11e9-8d6e-7e80fe1047cc.png)

To:

```javascript
log('Querying Authors & Articles source:', 'Local');
```

![Screen Shot 2019-10-06 at 7 16 33 PM](https://user-images.githubusercontent.com/3136873/66278471-e6ef4d80-e86e-11e9-9af7-961dd11b68d2.png)


