### PR TITLE
Set rootPath to define site index

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-node.js
+++ b/@narative/gatsby-theme-novela/gatsby-node.js
@@ -4,3 +4,4 @@ exports.onCreateNode = require('./gatsby/node/onCreateNode');
 exports.onCreateWebpackConfig = require('./gatsby/node/onCreateWebpackConfig');
 exports.onPreBootstrap = require('./gatsby/node/onPreBootstrap');
 exports.sourceNodes = require('./gatsby/node/sourceNodes');
+exports.createSchemaCustomization = require('./gatsby/node/createSchemaCustomization');

--- a/@narative/gatsby-theme-novela/gatsby/node/createPages.js
+++ b/@narative/gatsby-theme-novela/gatsby/node/createPages.js
@@ -48,6 +48,7 @@ const byDate = (a, b) => new Date(b.dateForSEO) - new Date(a.dateForSEO);
 
 module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
   const {
+    rootPath = '/',
     basePath = '/',
     authorsPath = '/authors',
     authorsPage = true,
@@ -68,6 +69,7 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
     netlify: { authors: [], articles: [] },
   };
 
+  log('Config rootPath', rootPath);
   log('Config basePath', basePath);
   if (authorsPage) log('Config authorsPath', authorsPath);
 

--- a/@narative/gatsby-theme-novela/gatsby/node/createPages.js
+++ b/@narative/gatsby-theme-novela/gatsby/node/createPages.js
@@ -48,7 +48,7 @@ const byDate = (a, b) => new Date(b.dateForSEO) - new Date(a.dateForSEO);
 
 module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
   const {
-    rootPath = '/',
+    rootPath,
     basePath = '/',
     authorsPath = '/authors',
     authorsPage = true,
@@ -69,7 +69,12 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
     netlify: { authors: [], articles: [] },
   };
 
-  log('Config rootPath', rootPath);
+  if (rootPath) {
+    log('Config rootPath', rootPath);
+  } else {
+    log('Config rootPath not set, using basePath instead =>', basePath);
+  }
+
   log('Config basePath', basePath);
   if (authorsPage) log('Config authorsPath', authorsPath);
 

--- a/@narative/gatsby-theme-novela/gatsby/node/createSchemaCustomization.js
+++ b/@narative/gatsby-theme-novela/gatsby/node/createSchemaCustomization.js
@@ -1,0 +1,14 @@
+module.exports = ({ actions }) => {
+  const { createTypes } = actions;
+
+  const typeDefs = `
+    type PluginOptions {
+      rootPath: String
+    }
+    type SitePlugin implements Node {
+      pluginOptions: PluginOptions
+    }
+  `;
+
+  createTypes(typeDefs);
+};

--- a/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
@@ -19,6 +19,7 @@ const siteQuery = graphql`
     sitePlugin(name: { eq: "@narative/gatsby-theme-novela" }) {
       pluginOptions {
         rootPath
+        basePath
       }
     }
   }
@@ -31,7 +32,7 @@ function NavigationHeader() {
 
   const [colorMode] = useColorMode();
   const fill = colorMode === "dark" ? "#fff" : "#000";
-  const { rootPath } = sitePlugin.pluginOptions;
+  const { rootPath, basePath } = sitePlugin.pluginOptions;
 
   useEffect(() => {
     const { width } = getWindowDimensions();
@@ -39,7 +40,7 @@ function NavigationHeader() {
 
     const prev = localStorage.getItem("previousPath");
     const previousPathWasHomepage =
-      prev === rootPath || (prev && prev.includes("/page/"));
+      prev === (rootPath || basePath) || (prev && prev.includes("/page/"));
     const isNotPaginated = !location.pathname.includes("/page/");
 
     setShowBackArrow(
@@ -52,7 +53,7 @@ function NavigationHeader() {
     <Section>
       <NavContainer>
         <LogoLink
-          to={rootPath}
+          to={rootPath || basePath}
           data-a11y="false"
           title="Navigate back to the homepage"
           aria-label="Navigate back to the homepage"

--- a/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import styled from "@emotion/styled";
-import { Link, navigate } from "gatsby";
+import { Link, navigate, graphql, useStaticQuery } from "gatsby";
 import { useColorMode } from "theme-ui";
 
 import Section from "@components/Section";
@@ -14,12 +14,24 @@ import {
   getBreakpointFromTheme,
 } from "@utils";
 
+const siteQuery = graphql`
+  {
+    sitePlugin(name: { eq: "@narative/gatsby-theme-novela" }) {
+      pluginOptions {
+        rootPath
+      }
+    }
+  }
+`;
+
 function NavigationHeader() {
   const [showBackArrow, setShowBackArrow] = useState<boolean>(false);
   const [previousPath, setPreviousPath] = useState<string>("/");
+  const { sitePlugin } = useStaticQuery(siteQuery);
 
   const [colorMode] = useColorMode();
   const fill = colorMode === "dark" ? "#fff" : "#000";
+  const { rootPath } = sitePlugin.pluginOptions;
 
   useEffect(() => {
     const { width } = getWindowDimensions();
@@ -27,7 +39,7 @@ function NavigationHeader() {
 
     const prev = localStorage.getItem("previousPath");
     const previousPathWasHomepage =
-      prev === "/" || (prev && prev.includes("/page/"));
+      prev === rootPath || (prev && prev.includes("/page/"));
     const isNotPaginated = !location.pathname.includes("/page/");
 
     setShowBackArrow(
@@ -40,7 +52,7 @@ function NavigationHeader() {
     <Section>
       <NavContainer>
         <LogoLink
-          to="/"
+          to={rootPath}
           data-a11y="false"
           title="Navigate back to the homepage"
           aria-label="Navigate back to the homepage"

--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -40,6 +40,7 @@ const plugins = [
     options: {
       contentPosts: "content/posts",
       contentAuthors: "content/authors",
+      rootPath: "/",
       basePath: "/",
       authorsPage: true,
       mailchimp: true,


### PR DESCRIPTION
Right now, if we click on the logo we are always taken to the `/` path. (#163)

This change adds the `rootPath` plugin option to let users define the index of their site, it then fetches the `rootPath` and uses that as the link for the logo.

![novela-2](https://user-images.githubusercontent.com/3136873/66363826-2db37500-e94d-11e9-8fa9-89ba8e5bd805.gif)
