### PR TITLE
feat: adding workflows for GH Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Yarn Install
+      run: yarn
     - name: Lerna
-      run: npx lerna publish --yes --git-remote pub
+      run: yarn lerna publish --yes --git-remote pub
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Yarn Install
       run: yarn
     - name: Lerna
-      run: yarn lerna publish --yes --git-remote pub
+      run: yarn lerna publish --yes --registry https//registry.npmjs.org/:_authToken=${NPM_TOKEN}
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Yarn Install
       run: yarn
     - name: Lerna
-      run: yarn lerna publish --yes --registry https//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+      run: yarn lerna publish --yes --registry https://registry.npmjs.org/:_authToken=${NPM_TOKEN}
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish with Lerna
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  CI_Workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Lerna
+      run: npx lerna publish --yes --git-remote pub
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -1,0 +1,19 @@
+name: CI for PR
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  CI_Workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Yarn Install
+      run: yarn install
+    - name: Yarn Lint
+      run: yarn lint
+    - name: Yarn Build
+      run: yarn build


### PR DESCRIPTION
# Draft PR to move CI to GitHub Actions and off Travis and Netlify

## Context
Netlify pricing change makes no sense. Travis is a third-party. 
Moving all CI to GitHub Actions would make maintenance easier and more lean. 

## What is this achieving
pulls.yml handles the CI on PR. It basically run `yarn install && yarn lint && yarn build`. It passes if none of these commands gets an error

publish.yml is to be tested but should run `lerna publish` when master gets a new commit. 
I reused `npx` from travis.yml but since we're off travis, maybe we can just do `yarn lerna publish`

## Requirements
This repo should have GH Actions enabled for this to work

## To-Do
[] Validate that Lerna publish works with this setup. 
[] Remove travis.yml