### PR TITLE
fix: font size inflation for mobile view in code box

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/MDX/MDX.tsx
+++ b/@narative/gatsby-theme-novela/src/components/MDX/MDX.tsx
@@ -188,6 +188,7 @@ const PrismCSS = p => css`
     `};
 
     ${mediaqueries.phablet`
+      text-size-adjust: none;
       border-radius: 0;
       margin: 0 auto 25px;
       padding: 25px 20px;


### PR DESCRIPTION
This PR fixes the current issue on mobile browser view. When the content of a code-box in an article is overflowing the container, the browser apply an inflation to the content font-size automatically (tested on Safari and Chrome). This inflation make the content code font-size too big and can break the overall page typography/design since other code-boxes will retain the original size (if there is no overflow). 

Before fixe (Safari / iPhone XS) 
![before-font-fixe](https://user-images.githubusercontent.com/49898644/66713641-691acd00-edad-11e9-92e9-9a4648adfdd4.png)

After fixe applied (Safari / iPhone XS) 
![after-font-fixe](https://user-images.githubusercontent.com/49898644/66713647-83ed4180-edad-11e9-84a8-2f7b89772414.png)

The fixe applied is a CSS property added to styled component PrismCSS. It prevents the browser to automatically apply the inflation algorithm to the font when there is an overflow.