### PR TITLE
SEO optimization for social links

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/SocialLinks/SocialLinks.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SocialLinks/SocialLinks.tsx
@@ -49,7 +49,7 @@ function SocialLinks({ links, fill = '#73737D' }: SocialLinksProps) {
           <SocialIconContainer
             key={option.url}
             target="_blank"
-            rel="noopener"
+            rel="noopener nofollow"
             data-a11y="false"
             aria-label={`Link to ${option.url}`}
             href={option.url}


### PR DESCRIPTION
Prevents bots from going to social link URLs. Improves website SEO/rank.

I use this on all my websites and this is the logic behind it:

When a bot crawls the page it looks for outbound links. (Outbound links are links that point the users away from your website. These types of links are most commonly found in social links.) When the bot crawls an outbound link, it follows the link and the linked page gets better rank because of that (authority etc.). This is what I call SEO leakage (I may be wrong). eg. By having an outbound link to facebook or twitter without nofollow, your website is improving the rank of Facebook or Twitter etc..

I have also read somewhere that the bots reduce your page rank because they had to index more other websites.

This PR adds `nofollow` to social links. It is not a deal breaker, but I believe that by implementing this the blog will rank better with search engines. It is a small change.