### PR TITLE
refactor: Use React.FC everywhere (WIP; see Todo)

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/Bio/Bio.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Bio/Bio.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import Image from '@components/Image';
 import { IAuthor } from '@types';
 
-function Bio({ author }: IAuthor) {
+const Bio: React.FC<IAuthor> = ({ author }) => {
   return (
     <BioContainer>
       <BioAvatar
@@ -21,7 +21,7 @@ function Bio({ author }: IAuthor) {
       <BioText dangerouslySetInnerHTML={{ __html: author.bio }} />
     </BioContainer>
   );
-}
+};
 
 export default Bio;
 

--- a/@narative/gatsby-theme-novela/src/components/Code/Code.Pre.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Code/Code.Pre.tsx
@@ -28,7 +28,7 @@ function preToCodeBlock(preProps) {
   }
 }
 
-function CodePre(preProps) {
+const CodePre: React.FC<{}> = (preProps) => {
   const props = preToCodeBlock(preProps);
 
   if (props) {
@@ -36,6 +36,6 @@ function CodePre(preProps) {
   } else {
     return <pre {...preProps} />;
   }
-}
+};
 
 export default CodePre;

--- a/@narative/gatsby-theme-novela/src/components/Code/Code.Prism.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Code/Code.Prism.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Highlight, { defaultProps } from "prism-react-renderer";
+import Highlight, { defaultProps, Language } from 'prism-react-renderer'
 import styled from "@emotion/styled";
 import { LiveProvider, LiveEditor, LiveError, LivePreview } from "react-live";
 import theme from "prism-react-renderer/themes/oceanicNext";
@@ -7,6 +7,39 @@ import theme from "prism-react-renderer/themes/oceanicNext";
 import Icons from "@icons";
 import mediaqueries from "@styles/media";
 import { copyToClipboard } from "@utils";
+
+interface CopyProps {
+  toCopy: string
+}
+
+const Copy: React.FC<CopyProps> = ({ toCopy }) => {
+  const [hasCopied, setHasCopied] = useState<boolean>(false);
+
+  function copyToClipboardOnClick() {
+    if (hasCopied) return;
+
+    copyToClipboard(toCopy);
+    setHasCopied(true);
+
+    setTimeout(() => {
+      setHasCopied(false);
+    }, 2000);
+  }
+
+  return (
+    <CopyButton onClick={copyToClipboardOnClick} data-a11y="false">
+      {hasCopied ? (
+        <>
+          Copied <Icons.Copied fill="#6f7177" />
+        </>
+      ) : (
+        <>
+          Copy <Icons.Copy fill="#6f7177" />
+        </>
+      )}
+    </CopyButton>
+  );
+};
 
 const RE = /{([\d,-]+)}/;
 
@@ -28,7 +61,18 @@ function calculateLinesToHighlight(meta) {
   }
 }
 
-function CodePrism({ codeString, language, metastring, ...props }) {
+interface CodePrismProps {
+  codeString: string;
+  language: Language;
+  metastring?: string;
+}
+
+const CodePrism: React.FC<CodePrismProps> = ({
+  codeString,
+  language,
+  metastring,
+  ...props
+}) => {
   const shouldHighlightLine = calculateLinesToHighlight(metastring);
 
   if (props["live"]) {
@@ -86,35 +130,6 @@ function CodePrism({ codeString, language, metastring, ...props }) {
 }
 
 export default CodePrism;
-
-function Copy({ toCopy }: { toCopy: string }) {
-  const [hasCopied, setHasCopied] = useState<boolean>(false);
-
-  function copyToClipboardOnClick() {
-    if (hasCopied) return;
-
-    copyToClipboard(toCopy);
-    setHasCopied(true);
-
-    setTimeout(() => {
-      setHasCopied(false);
-    }, 2000);
-  }
-
-  return (
-    <CopyButton onClick={copyToClipboardOnClick} data-a11y="false">
-      {hasCopied ? (
-        <>
-          Copied <Icons.Copied fill="#6f7177" />
-        </>
-      ) : (
-        <>
-          Copy <Icons.Copy fill="#6f7177" />
-        </>
-      )}
-    </CopyButton>
-  );
-}
 
 const CopyButton = styled.button`
   position: absolute;

--- a/@narative/gatsby-theme-novela/src/components/Image/Image.Placeholder.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Image/Image.Placeholder.tsx
@@ -19,7 +19,7 @@ const Container = styled.div`
   `}
 `;
 
-function ImagePlaceholder(props) {
+const ImagePlaceholder: React.FC<{}> = (props) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
 
@@ -40,6 +40,6 @@ function ImagePlaceholder(props) {
       </div>
     </Container>
   );
-}
+};
 
 export default ImagePlaceholder;

--- a/@narative/gatsby-theme-novela/src/components/Image/Image.Zoom.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Image/Image.Zoom.tsx
@@ -15,7 +15,7 @@ function handleImageZoomBackground(background: string) {
   });
 }
 
-function ImageZoom(props) {
+const ImageZoom: React.FC<{}> = (props) => {
   const { theme } = useThemeUI();
 
   const image = {
@@ -40,6 +40,6 @@ function ImageZoom(props) {
       }}
     />
   );
-}
+};
 
 export default ImageZoom;

--- a/@narative/gatsby-theme-novela/src/components/Image/Image.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Image/Image.tsx
@@ -30,7 +30,7 @@ const StyledGatsbyImag = styled(GatsbyImg)`
  *
  * todo : lazyload the default img tag
  */
-const Image: React.SFC<IImg> = ({ src, alt, ...props }) => {
+const Image: React.FC<IImg> = ({ src, alt, ...props }) => {
   // We're going to build our final component's props dynamically.
   // So create a nice default set of props that are relevant to Gatsby and non Gatsby images
   const imgProps = {

--- a/@narative/gatsby-theme-novela/src/components/Layout/Layout.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Layout/Layout.tsx
@@ -9,16 +9,12 @@ import ArticlesContextProvider from '../../sections/articles/Articles.List.Conte
 
 import { globalStyles } from '@styles';
 
-interface LayoutProps {
-  children: React.ReactChild;
-}
-
 /**
  * <Layout /> needs to wrap every page as it provides styles, navigation,
  * and the main structure of each page. Within Layout we have the <Container />
  * which hides a lot of the mess we need to create our Desktop and Mobile experiences.
  */
-function Layout({ children }: LayoutProps) {
+const Layout: React.FC<{}> = ({ children }) => {
   const [colorMode] = useColorMode();
 
   useEffect(() => {

--- a/@narative/gatsby-theme-novela/src/components/Logo/Logo.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Logo/Logo.tsx
@@ -3,7 +3,9 @@ import styled from "@emotion/styled";
 
 import mediaqueries from "@styles/media";
 
-const Logo = ({ fill = "#fff" }: { fill?: string }) => {
+import { Icon } from '@types';
+
+const Logo: Icon = ({ fill = "white" }) => {
   return (
     <LogoContainer>
       <svg

--- a/@narative/gatsby-theme-novela/src/components/MDX/MDX.tsx
+++ b/@narative/gatsby-theme-novela/src/components/MDX/MDX.tsx
@@ -42,7 +42,11 @@ const components = {
   td: Tables.Cell
 };
 
-function MDX({ content, children, ...props }) {
+interface MDXProps {
+  content: React.ReactNode;
+}
+
+const MDX: React.FC<MDXProps> = ({ content, children, ...props }) => {
   const [colorMode] = useColorMode();
 
   return (
@@ -55,7 +59,7 @@ function MDX({ content, children, ...props }) {
       </MDXBody>
     </MDXProvider>
   );
-}
+};
 
 export default MDX;
 

--- a/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Footer.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Footer.tsx
@@ -25,7 +25,7 @@ const siteQuery = graphql`
   }
 `;
 
-function Footer() {
+const Footer: React.FC<{}> = () => {
   const results = useStaticQuery(siteQuery);
   const { name, social } = results.allSite.edges[0].node.siteMetadata;
 
@@ -45,7 +45,7 @@ function Footer() {
       </Section>
     </>
   );
-}
+};
 
 export default Footer;
 

--- a/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
@@ -25,7 +25,63 @@ const siteQuery = graphql`
   }
 `;
 
-function NavigationHeader() {
+const DarkModeToggle: React.FC<{}> = () => {
+  const [colorMode, setColorMode] = useColorMode();
+  const isDark = colorMode === `dark`;
+
+  function toggleColorMode(event) {
+    event.preventDefault();
+    setColorMode(isDark ? `light` : `dark`);
+  }
+
+  return (
+    <IconWrapper
+      isDark={isDark}
+      onClick={toggleColorMode}
+      data-a11y="false"
+      aria-label={isDark ? "Activate light mode" : "Activate dark mode"}
+      title={isDark ? "Activate light mode" : "Activate dark mode"}
+    >
+      <MoonOrSun isDark={isDark} />
+      <MoonMask isDark={isDark} />
+    </IconWrapper>
+  );
+};
+
+const SharePageButton: React.FC<{}> = () => {
+  const [hasCopied, setHasCopied] = useState<boolean>(false);
+  const [colorMode] = useColorMode();
+  const isDark = colorMode === `dark`;
+  const fill = isDark ? "#fff" : "#000";
+
+  function copyToClipboardOnClick() {
+    if (hasCopied) return;
+
+    copyToClipboard(window.location.href);
+    setHasCopied(true);
+
+    setTimeout(() => {
+      setHasCopied(false);
+    }, 1000);
+  }
+
+  return (
+    <IconWrapper
+      isDark={isDark}
+      onClick={copyToClipboardOnClick}
+      data-a11y="false"
+      aria-label="Copy URL to clipboard"
+      title="Copy URL to clipboard"
+    >
+      <Icons.Link fill={fill} />
+      <ToolTip isDark={isDark} hasCopied={hasCopied}>
+        Copied
+      </ToolTip>
+    </IconWrapper>
+  );
+};
+
+const NavigationHeader: React.FC<{}> = () => {
   const [showBackArrow, setShowBackArrow] = useState<boolean>(false);
   const [previousPath, setPreviousPath] = useState<string>("/");
   const { sitePlugin } = useStaticQuery(siteQuery);
@@ -86,65 +142,9 @@ function NavigationHeader() {
       </NavContainer>
     </Section>
   );
-}
+};
 
 export default NavigationHeader;
-
-function DarkModeToggle() {
-  const [colorMode, setColorMode] = useColorMode();
-  const isDark = colorMode === `dark`;
-
-  function toggleColorMode(event) {
-    event.preventDefault();
-    setColorMode(isDark ? `light` : `dark`);
-  }
-
-  return (
-    <IconWrapper
-      isDark={isDark}
-      onClick={toggleColorMode}
-      data-a11y="false"
-      aria-label={isDark ? "Activate light mode" : "Activate dark mode"}
-      title={isDark ? "Activate light mode" : "Activate dark mode"}
-    >
-      <MoonOrSun isDark={isDark} />
-      <MoonMask isDark={isDark} />
-    </IconWrapper>
-  );
-}
-
-function SharePageButton() {
-  const [hasCopied, setHasCopied] = useState<boolean>(false);
-  const [colorMode] = useColorMode();
-  const isDark = colorMode === `dark`;
-  const fill = isDark ? "#fff" : "#000";
-
-  function copyToClipboardOnClick() {
-    if (hasCopied) return;
-
-    copyToClipboard(window.location.href);
-    setHasCopied(true);
-
-    setTimeout(() => {
-      setHasCopied(false);
-    }, 1000);
-  }
-
-  return (
-    <IconWrapper
-      isDark={isDark}
-      onClick={copyToClipboardOnClick}
-      data-a11y="false"
-      aria-label="Copy URL to clipboard"
-      title="Copy URL to clipboard"
-    >
-      <Icons.Link fill={fill} />
-      <ToolTip isDark={isDark} hasCopied={hasCopied}>
-        Copied
-      </ToolTip>
-    </IconWrapper>
-  );
-}
 
 const BackArrowIconContainer = styled.div`
   transition: 0.2s transform var(--ease-out-quad);

--- a/@narative/gatsby-theme-novela/src/components/Progress/Progress.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Progress/Progress.tsx
@@ -8,7 +8,7 @@ export interface IProgress {
   contentHeight: number;
 }
 
-function Progress({ contentHeight }: IProgress) {
+const Progress: React.FC<IProgress> = ({ contentHeight }) => {
   const [progress, setProgress] = useState<number>(0);
 
   useEffect(() => {
@@ -35,7 +35,7 @@ function Progress({ contentHeight }: IProgress) {
       </Trackline>
     </ProgressContainer>
   );
-}
+};
 
 export default Progress;
 

--- a/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
@@ -22,7 +22,6 @@ import Helmet from 'react-helmet';
 import { graphql, useStaticQuery } from 'gatsby';
 
 interface HelmetProps {
-  children?: React.ReactChildren;
   title: string;
   description?: string;
   pathname: string;
@@ -68,7 +67,7 @@ const themeUIDarkModeWorkaroundScript = [
   },
 ];
 
-function SEO({
+const SEO: React.FC<HelmetProps> = ({
   title,
   description,
   children,
@@ -77,7 +76,7 @@ function SEO({
   published,
   pathname,
   timeToRead,
-}: HelmetProps) {
+}) => {
   const results = useStaticQuery(seoQuery);
   const site = results.allSite.edges[0].node.siteMetadata;
   const twitter = site.social.find(option => option.name === 'twitter') || {};
@@ -151,6 +150,6 @@ function SEO({
       {children}
     </Helmet>
   );
-}
+};
 
 export default SEO;

--- a/@narative/gatsby-theme-novela/src/components/SocialLinks/SocialLinks.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SocialLinks/SocialLinks.tsx
@@ -33,7 +33,10 @@ const getHostname = url => {
   return new URL(url.toLowerCase()).hostname.replace('www.', '').split('.')[0];
 };
 
-function SocialLinks({ links, fill = '#73737D' }: SocialLinksProps) {
+const SocialLinks: React.FC<SocialLinksProps> = ({
+  links,
+  fill = '#73737D'
+}) => {
   if (!links) return null;
 
   return (
@@ -62,7 +65,7 @@ function SocialLinks({ links, fill = '#73737D' }: SocialLinksProps) {
       })}
     </>
   );
-}
+};
 
 export default SocialLinks;
 

--- a/@narative/gatsby-theme-novela/src/components/Subscription/Subscription.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Subscription/Subscription.tsx
@@ -7,7 +7,7 @@ import Headings from "@components/Headings";
 import styled from "@emotion/styled";
 import mediaqueries from "@styles/media";
 
-const Subscription: React.FunctionComponent<{}> = () => {
+const Subscription: React.FC<{}> = () => {
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [subscribed, setSubscribed] = useState(false);

--- a/@narative/gatsby-theme-novela/src/components/Tables/Table.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Tables/Table.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import styled from "@emotion/styled";
 import mediaqueries from "@styles/media";
 
@@ -29,12 +30,12 @@ const StyledTable = styled.table`
   `};
 `;
 
-function Table({ children }) {
+const Table: React.FC<{}> = ({ children }) => {
   return (
     <div style={{ overflowX: "auto", padding: "0 20px" }}>
       <StyledTable>{children}</StyledTable>
     </div>
   );
-}
+};
 
 export default Table;

--- a/@narative/gatsby-theme-novela/src/components/Transitions/Transitions.CSS.FadeIn.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Transitions/Transitions.CSS.FadeIn.tsx
@@ -4,12 +4,11 @@ import { keyframes } from "@emotion/core";
 
 interface CSSFadeInProps {
   as?: string;
-  children: React.ReactChildren;
 }
 
-function CSSFadeIn({ as, children }: CSSFadeInProps) {
+const CSSFadeIn: React.FC<CSSFadeInProps> = ({ as, children }) => {
   return <Transition as={as}>{children}</Transition>;
-}
+};
 
 export default CSSFadeIn;
 

--- a/@narative/gatsby-theme-novela/src/icons/social/Behance.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Behance.Icon.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-const BehanceIcon = ({ fill = '#fff' }) => (
+import { Icon } from '@types';
+
+const BehanceIcon: Icon = ({ fill = "white" }) => (
   <svg
     version="1.1"
     xmlns="http://www.w3.org/2000/svg"

--- a/@narative/gatsby-theme-novela/src/icons/social/DigitalOcean.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/DigitalOcean.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const DigitalOceanIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const DigitalOceanIcon: Icon = ({ fill = "white" }) => (
     <svg
         width="14"
         height="14"

--- a/@narative/gatsby-theme-novela/src/icons/social/Dribbble.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Dribbble.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const DribbbleIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const DribbbleIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="14"
     height="14"

--- a/@narative/gatsby-theme-novela/src/icons/social/Facebook.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Facebook.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const FacebookIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const FacebookIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="7"
     height="14"

--- a/@narative/gatsby-theme-novela/src/icons/social/Github.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Github.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const GithubIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const GithubIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="14"
     height="14"

--- a/@narative/gatsby-theme-novela/src/icons/social/Instagram.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Instagram.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const InstagramIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const InstagramIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="13"
     height="13"

--- a/@narative/gatsby-theme-novela/src/icons/social/LinkedIn.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/LinkedIn.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const LinkedinIcon = ({ fill = "white", ...props }) => (
+import { Icon } from '@types';
+
+const LinkedinIcon: Icon = ({ fill = "white", ...props }) => (
   <svg
     width="14"
     height="14"

--- a/@narative/gatsby-theme-novela/src/icons/social/Medium.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Medium.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const MediumIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const MediumIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="13"
     height="11"

--- a/@narative/gatsby-theme-novela/src/icons/social/Patreon.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Patreon.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const PatreonIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const PatreonIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="14"
     height="14"

--- a/@narative/gatsby-theme-novela/src/icons/social/Paypal.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Paypal.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const PaypalIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const PaypalIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="14"
     height="14"

--- a/@narative/gatsby-theme-novela/src/icons/social/Stackoverflow.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Stackoverflow.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const StackoverflowIcon = ({fill = "white"}) => (
+import { Icon } from '@types';
+
+const StackoverflowIcon: Icon = ({ fill = "white" }) => (
     <svg
       width="15"
       height="15"

--- a/@narative/gatsby-theme-novela/src/icons/social/Twitter.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Twitter.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const TwitterIcon = ({ fill = "white", ...props }) => (
+import { Icon } from '@types';
+
+const TwitterIcon: Icon = ({ fill = "white", ...props }) => (
   <svg
     width="16"
     height="13"

--- a/@narative/gatsby-theme-novela/src/icons/social/Unsplash.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/Unsplash.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const UnsplashIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const UnsplashIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="15"
     height="15"

--- a/@narative/gatsby-theme-novela/src/icons/social/YouTube.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/social/YouTube.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const YouTubeIcon = ({ fill = "white" }) => (
+import { Icon } from '@types';
+
+const YouTubeIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="17"
     height="12"

--- a/@narative/gatsby-theme-novela/src/icons/ui/ChevronLeft.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/ui/ChevronLeft.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const ChevronLeft = ({ fill }) => (
+import { Icon } from '@types';
+
+const ChevronLeft: Icon = ({ fill }) => (
   <svg
     width="24"
     height="24"

--- a/@narative/gatsby-theme-novela/src/icons/ui/Copied.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/ui/Copied.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const CopiedIcon = ({ fill = "#fff" }) => (
+import { Icon } from '@types';
+
+const CopiedIcon: Icon = ({ fill = "white" }) => (
   <svg
     width="15"
     height="19"

--- a/@narative/gatsby-theme-novela/src/icons/ui/Copy.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/ui/Copy.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const CopyIcon = ({ fill = "#08080B", ...props }) => (
+import { Icon } from '@types';
+
+const CopyIcon: Icon = ({ fill = "#08080B", ...props }) => (
   <svg
     width="15"
     height="19"

--- a/@narative/gatsby-theme-novela/src/icons/ui/Ex.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/ui/Ex.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const ExIcon = ({ fill = "#08080B" }) => (
+import { Icon } from '@types';
+
+const ExIcon: Icon = ({ fill = "#08080B" }) => (
   <svg
     width="24"
     height="25"

--- a/@narative/gatsby-theme-novela/src/icons/ui/Link.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/ui/Link.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const LinkIcon = ({ fill }) => (
+import { Icon } from '@types';
+
+const LinkIcon: Icon = ({ fill }) => (
   <svg
     width="24"
     height="20"

--- a/@narative/gatsby-theme-novela/src/icons/ui/Rows.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/ui/Rows.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const RowsIcon = ({ fill }) => (
+import { Icon } from '@types';
+
+const RowsIcon: Icon = ({ fill }) => (
   <svg
     width="26"
     height="26"

--- a/@narative/gatsby-theme-novela/src/icons/ui/Tiles.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/ui/Tiles.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const TilesIcon = ({ fill }) => (
+import { Icon } from '@types';
+
+const TilesIcon: Icon = ({ fill }) => (
   <svg
     width="26"
     height="26"

--- a/@narative/gatsby-theme-novela/src/icons/ui/ToggleClose.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/ui/ToggleClose.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const ToggleClose = ({ fill }) => (
+import { Icon } from '@types';
+
+const ToggleClose: Icon = ({ fill }) => (
   <svg
     width="17"
     height="17"

--- a/@narative/gatsby-theme-novela/src/icons/ui/ToggleOpen.Icon.tsx
+++ b/@narative/gatsby-theme-novela/src/icons/ui/ToggleOpen.Icon.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-const ToggleOpen = ({ fill }) => (
+import { Icon } from '@types';
+
+const ToggleOpen: Icon = ({ fill }) => (
   <svg
     width="17"
     height="17"

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Aside.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Aside.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, ReactNode } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import styled from "@emotion/styled";
 import throttle from "lodash/throttle";
 
@@ -8,7 +8,6 @@ import mediaqueries from "@styles/media";
 import { clamp } from "@utils";
 
 interface AsideProps {
-  children: ReactNode[] | ReactNode;
   contentHeight: number;
 }
 
@@ -27,7 +26,7 @@ interface AsideProps {
  *                  |  content  |
  *
  */
-function Aside({ contentHeight, children }: AsideProps) {
+const Aside: React.FC<AsideProps> = ({ contentHeight, children }) => {
   const progressRef = useRef<HTMLDivElement>(null);
 
   const [progress, setProgress] = useState<number>(0);

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Authors.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Authors.tsx
@@ -10,34 +10,27 @@ import mediaqueries from "@styles/media";
 import { IAuthor } from "@types";
 
 /**
- * Novela supports multiple authors and therefore we need to ensure
- * we render the right UI when there are varying amount of authors.
+ * When generating the author names we're also checking to see how long the
+ * number of authors are. If it's only 2 authors we'll show the fullnames.
+ * Otherwise it'll only preview the first names of each author.
  */
-function ArticleAuthors({ authors }: { authors: IAuthor[] }) {
-  const hasCoAuthors = authors.length > 1;
-
-  // Special dropdown UI for multiple authors
-  if (hasCoAuthors) {
-    return <CoAuthors authors={authors} />;
-  } else {
-    return (
-      <AuthorLink
-        as={authors[0].authorsPage ? Link : "div"}
-        to={authors[0].slug}
-      >
-        <AuthorAvatar>
-          <Image src={authors[0].avatar.small} />
-        </AuthorAvatar>
-        <strong>{authors[0].name}</strong>
-        <HideOnMobile>,&nbsp;</HideOnMobile>
-      </AuthorLink>
-    );
-  }
+function generateAuthorNames(authors: IAuthor[]) {
+  return authors
+    .map(author => {
+      if (authors.length > 2) {
+        return author.name.split(" ")[0];
+      } else {
+        return author.name;
+      }
+    })
+    .join(", ");
 }
 
-export default ArticleAuthors;
+interface AuthorsProps {
+  authors: IAuthor[]
+}
 
-function CoAuthors({ authors }: { authors: IAuthor[] }) {
+const CoAuthors: React.FC<AuthorsProps> = ({ authors }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [colorMode] = useColorMode();
   const names = generateAuthorNames(authors);
@@ -83,24 +76,35 @@ function CoAuthors({ authors }: { authors: IAuthor[] }) {
       )}
     </CoAuthorsContainer>
   );
-}
+};
 
 /**
- * When generating the author names we're also checking to see how long the
- * number of authors are. If it's only 2 authors we'll show the fullnames.
- * Otherwise it'll only preview the first names of each author.
+ * Novela supports multiple authors and therefore we need to ensure
+ * we render the right UI when there are varying amount of authors.
  */
-function generateAuthorNames(authors: IAuthor[]) {
-  return authors
-    .map(author => {
-      if (authors.length > 2) {
-        return author.name.split(" ")[0];
-      } else {
-        return author.name;
-      }
-    })
-    .join(", ");
-}
+const ArticleAuthors: React.FC<AuthorsProps> = ({ authors }) => {
+  const hasCoAuthors = authors.length > 1;
+
+  // Special dropdown UI for multiple authors
+  if (hasCoAuthors) {
+    return <CoAuthors authors={authors} />;
+  } else {
+    return (
+      <AuthorLink
+        as={authors[0].authorsPage ? Link : "div"}
+        to={authors[0].slug}
+      >
+        <AuthorAvatar>
+          <Image src={authors[0].avatar.small} />
+        </AuthorAvatar>
+        <strong>{authors[0].name}</strong>
+        <HideOnMobile>,&nbsp;</HideOnMobile>
+      </AuthorLink>
+    );
+  }
+};
+
+export default ArticleAuthors;
 
 const AuthorAvatar = styled.div`
   height: 25px;

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Controls.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Controls.tsx
@@ -5,18 +5,41 @@ import { useColorMode } from "theme-ui";
 import mediaqueries from "@styles/media";
 import { copyToClipboard } from "@utils";
 
-function ArticleControls() {
-  return (
-    <NavControls>
-      <SharePageButton />
-      <DarkModeToggle />
-    </NavControls>
-  );
-}
+const ShareDarkModeOffIcon: React.FC<{}> = () => (
+  <svg
+    width="24"
+    height="20"
+    viewBox="0 0 24 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M2 5C2 3.34328 3.34328 2 5 2H14C15.6567 2 17 3.34328 17 5V9C17 10.6567 15.6567 12 14 12H10C9.44771 12 9 12.4477 9 13C9 13.5523 9.44771 14 10 14H14C16.7613 14 19 11.7613 19 9V5C19 2.23872 16.7613 0 14 0H5C2.23872 0 0 2.23872 0 5V9C0 10.4938 0.656313 11.8361 1.6935 12.7509C2.10768 13.1163 2.73961 13.0767 3.10494 12.6625C3.47028 12.2483 3.43068 11.6164 3.0165 11.2511C2.39169 10.6999 2 9.89621 2 9V5ZM7 11C7 9.34328 8.34328 8 10 8H14C14.5523 8 15 7.55228 15 7C15 6.44772 14.5523 6 14 6H10C7.23872 6 5 8.23872 5 11V15C5 17.7613 7.23872 20 10 20H19C21.7613 20 24 17.7613 24 15V11C24 9.50621 23.3437 8.16393 22.3065 7.24906C21.8923 6.88372 21.2604 6.92332 20.8951 7.3375C20.5297 7.75168 20.5693 8.38361 20.9835 8.74894C21.6083 9.30007 22 10.1038 22 11V15C22 16.6567 20.6567 18 19 18H10C8.34328 18 7 16.6567 7 15V11Z"
+      fill="white"
+    />
+  </svg>
+);
 
-export default ArticleControls;
+const ShareDarkModeOnIcon: React.FC<{}> = () => (
+  <svg
+    width="24"
+    height="20"
+    viewBox="0 0 24 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M2 5C2 3.34328 3.34328 2 5 2H14C15.6567 2 17 3.34328 17 5V9C17 10.6567 15.6567 12 14 12H10C9.44771 12 9 12.4477 9 13C9 13.5523 9.44771 14 10 14H14C16.7613 14 19 11.7613 19 9V5C19 2.23872 16.7613 0 14 0H5C2.23872 0 0 2.23872 0 5V9C0 10.4938 0.656313 11.8361 1.6935 12.7509C2.10768 13.1163 2.73961 13.0767 3.10494 12.6625C3.47028 12.2483 3.43068 11.6164 3.0165 11.2511C2.39169 10.6999 2 9.89621 2 9V5ZM7 11C7 9.34328 8.34328 8 10 8H14C14.5523 8 15 7.55228 15 7C15 6.44772 14.5523 6 14 6H10C7.23872 6 5 8.23872 5 11V15C5 17.7613 7.23872 20 10 20H19C21.7613 20 24 17.7613 24 15V11C24 9.50621 23.3437 8.16393 22.3065 7.24906C21.8923 6.88372 21.2604 6.92332 20.8951 7.3375C20.5297 7.75168 20.5693 8.38361 20.9835 8.74894C21.6083 9.30007 22 10.1038 22 11V15C22 16.6567 20.6567 18 19 18H10C8.34328 18 7 16.6567 7 15V11Z"
+      fill="black"
+    />
+  </svg>
+);
 
-function DarkModeToggle() {
+const DarkModeToggle: React.FC<{}> = () => {
   const [colorMode, setColorMode] = useColorMode();
   const isDark = colorMode === `dark`;
 
@@ -34,9 +57,9 @@ function DarkModeToggle() {
       <MoonMask isDark={isDark} />
     </IconWrapper>
   );
-}
+};
 
-function SharePageButton() {
+const SharePageButton: React.FC<{}> = () => {
   const [hasCopied, setHasCopied] = useState<boolean>(false);
   const [colorMode] = useColorMode();
   const isDark = colorMode === `dark`;
@@ -66,41 +89,18 @@ function SharePageButton() {
       </ToolTip>
     </IconWrapper>
   );
-}
+};
 
-const ShareDarkModeOffIcon = () => (
-  <svg
-    width="24"
-    height="20"
-    viewBox="0 0 24 20"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M2 5C2 3.34328 3.34328 2 5 2H14C15.6567 2 17 3.34328 17 5V9C17 10.6567 15.6567 12 14 12H10C9.44771 12 9 12.4477 9 13C9 13.5523 9.44771 14 10 14H14C16.7613 14 19 11.7613 19 9V5C19 2.23872 16.7613 0 14 0H5C2.23872 0 0 2.23872 0 5V9C0 10.4938 0.656313 11.8361 1.6935 12.7509C2.10768 13.1163 2.73961 13.0767 3.10494 12.6625C3.47028 12.2483 3.43068 11.6164 3.0165 11.2511C2.39169 10.6999 2 9.89621 2 9V5ZM7 11C7 9.34328 8.34328 8 10 8H14C14.5523 8 15 7.55228 15 7C15 6.44772 14.5523 6 14 6H10C7.23872 6 5 8.23872 5 11V15C5 17.7613 7.23872 20 10 20H19C21.7613 20 24 17.7613 24 15V11C24 9.50621 23.3437 8.16393 22.3065 7.24906C21.8923 6.88372 21.2604 6.92332 20.8951 7.3375C20.5297 7.75168 20.5693 8.38361 20.9835 8.74894C21.6083 9.30007 22 10.1038 22 11V15C22 16.6567 20.6567 18 19 18H10C8.34328 18 7 16.6567 7 15V11Z"
-      fill="white"
-    />
-  </svg>
-);
+const ArticleControls: React.FC<{}> = () => {
+  return (
+    <NavControls>
+      <SharePageButton />
+      <DarkModeToggle />
+    </NavControls>
+  );
+};
 
-const ShareDarkModeOnIcon = () => (
-  <svg
-    width="24"
-    height="20"
-    viewBox="0 0 24 20"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M2 5C2 3.34328 3.34328 2 5 2H14C15.6567 2 17 3.34328 17 5V9C17 10.6567 15.6567 12 14 12H10C9.44771 12 9 12.4477 9 13C9 13.5523 9.44771 14 10 14H14C16.7613 14 19 11.7613 19 9V5C19 2.23872 16.7613 0 14 0H5C2.23872 0 0 2.23872 0 5V9C0 10.4938 0.656313 11.8361 1.6935 12.7509C2.10768 13.1163 2.73961 13.0767 3.10494 12.6625C3.47028 12.2483 3.43068 11.6164 3.0165 11.2511C2.39169 10.6999 2 9.89621 2 9V5ZM7 11C7 9.34328 8.34328 8 10 8H14C14.5523 8 15 7.55228 15 7C15 6.44772 14.5523 6 14 6H10C7.23872 6 5 8.23872 5 11V15C5 17.7613 7.23872 20 10 20H19C21.7613 20 24 17.7613 24 15V11C24 9.50621 23.3437 8.16393 22.3065 7.24906C21.8923 6.88372 21.2604 6.92332 20.8951 7.3375C20.5297 7.75168 20.5693 8.38361 20.9835 8.74894C21.6083 9.30007 22 10.1038 22 11V15C22 16.6567 20.6567 18 19 18H10C8.34328 18 7 16.6567 7 15V11Z"
-      fill="black"
-    />
-  </svg>
-);
+export default ArticleControls;
 
 const NavControls = styled.div`
   display: flex;

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.HandleOverlap.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.HandleOverlap.tsx
@@ -2,14 +2,6 @@ import React, { useEffect, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import throttle from "lodash/throttle";
 
-interface OverlapProps {
-  children: React.ReactNode[];
-}
-
-interface OverlapState {
-  isOverlapping: boolean;
-}
-
 /**
  * <HandleOverlap />
  * This is similar to Medium's "show and hide" the sidebar if it's overlapping an
@@ -20,10 +12,9 @@ interface OverlapState {
  * and decides wether or not they're overlapping (with some buffer). If they are overlapping
  * we want to hide the top element.
  */
-
-function HandleOverlap(props: OverlapProps) {
+const HandleOverlap: React.FC<{}> = (props) => {
   const asideRef = useRef<HTMLDivElement>(null);
-  const [isOverlapping, setIsOverlapping] = useState<OverlapState>(false);
+  const [isOverlapping, setIsOverlapping] = useState(false);
 
   // Is the current element within the window's frame? That's all we care about!
   function isVisible(element: HTMLElement): boolean {

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Hero.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Hero.tsx
@@ -14,7 +14,7 @@ interface ArticleHeroProps {
   authors: IAuthor[];
 }
 
-const ArticleHero = ({ article, authors }: ArticleHeroProps) => {
+const ArticleHero: React.FC<ArticleHeroProps> = ({ article, authors }) => {
   const hasCoAUthors = authors.length > 1;
   const hasHeroImage =
     Object.keys(article.hero.full).length !== 0 &&

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Next.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Next.tsx
@@ -10,6 +10,10 @@ import mediaqueries from "@styles/media";
 
 import { IArticle } from "@types";
 
+interface ArticlesNextProps {
+  articles: IArticle[]
+}
+
 /**
  * Sits at the bottom of our Article page. Shows the next 2 on desktop and the
  * next 1 on mobile!
@@ -22,7 +26,7 @@ import { IArticle } from "@types";
  * as the next one suggested article, which requires special styling we didn't want to
  * mix into the generic list component.
  */
-const ArticlesNext = ({ articles }: { articles: IArticle[] }) => {
+const ArticlesNext: React.FC<ArticlesNextProps> = ({ articles }) => {
   if (!articles) return null;
   const numberOfArticles = articles.length;
   return (
@@ -35,13 +39,12 @@ const ArticlesNext = ({ articles }: { articles: IArticle[] }) => {
 
 export default ArticlesNext;
 
-const GridItem = ({
-  article,
-  narrow,
-}: {
+interface GridItemProps {
   article: IArticle;
   narrow?: boolean;
-}) => {
+}
+
+const GridItem: React.FC<GridItemProps> = ({ article, narrow }) => {
   if (!article) return null;
 
   const hasOverflow = narrow && article.title.length > 35;

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
@@ -20,15 +20,17 @@ const siteQuery = graphql`
   }
 `;
 
-function ArticleSEO({
+interface ArticleSEOProps {
+  article: IArticle;
+  authors: IAuthor[];
+  location: Location;
+}
+
+const ArticleSEO: React.FC<ArticleSEOProps> = ({
   article,
   authors,
   location,
-}: {
-  article: IArticle;
-  authors: IAuthor[];
-  location: any;
-}) {
+}) => {
   const results = useStaticQuery(siteQuery);
   const name = results.allSite.edges[0].node.siteMetadata.name;
   const siteUrl = results.allSite.edges[0].node.siteMetadata.siteUrl;
@@ -88,6 +90,6 @@ function ArticleSEO({
       <script type="application/ld+json">{microdata}</script>
     </SEO>
   );
-}
+};
 
 export default ArticleSEO;

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Share.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Share.tsx
@@ -26,7 +26,7 @@ interface MenuFloatState {
 const MENU_WIDTH: number = 225;
 const MENU_HEIGHT: number = 46;
 
-function ArticelShare() {
+const ArticleShare: React.FC<{}> = () => {
   const [colorMode] = useColorMode();
   const [text, setText] = useState("");
   const [focus, setFocus] = useState(false);
@@ -181,9 +181,9 @@ function ArticelShare() {
       </MenuButton>
     </MenuFloat>
   );
-}
+};
 
-export default ArticelShare;
+export default ArticleShare;
 
 function ReferralLink({ disabled, share, children }) {
   function handleClick(event) {

--- a/@narative/gatsby-theme-novela/src/sections/articles/Articles.Hero.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/articles/Articles.Hero.tsx
@@ -27,7 +27,7 @@ const authorQuery = graphql`
   }
 `;
 
-function ArticlesHero({ authors }: IAuthor) {
+const ArticlesHero: React.FC<IAuthor> = ({ authors }) => {
   const { gridLayout = 'tiles', hasSetGridLayout, setGridLayout } = useContext(
     GridLayoutContext,
   );
@@ -74,7 +74,7 @@ function ArticlesHero({ authors }: IAuthor) {
       </SubheadingContainer>
     </Section>
   );
-}
+};
 
 export default ArticlesHero;
 

--- a/@narative/gatsby-theme-novela/src/sections/articles/Articles.List.Context.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/articles/Articles.List.Context.tsx
@@ -1,9 +1,5 @@
 import React, { createContext, useState } from "react";
 
-interface GridLayoutProviderProps {
-  children: React.ReactChild;
-}
-
 export const GridLayoutContext = createContext({
   gridLayout: "tiles",
   hasSetGridLayout: false,
@@ -11,7 +7,7 @@ export const GridLayoutContext = createContext({
   getGridLayout: () => {},
 });
 
-function GridLayoutProvider({ children }: GridLayoutProviderProps) {
+const GridLayoutProvider: React.FC<{}> = ({ children }) => {
   const initialLayout = "tiles";
 
   const [gridLayout, setGridLayout] = useState<string>(initialLayout);
@@ -39,6 +35,6 @@ function GridLayoutProvider({ children }: GridLayoutProviderProps) {
       {children}
     </GridLayoutContext.Provider>
   );
-}
+};
 
 export default GridLayoutProvider;

--- a/@narative/gatsby-theme-novela/src/sections/articles/Articles.List.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/articles/Articles.List.tsx
@@ -35,7 +35,10 @@ interface ArticlesListItemProps {
   narrow?: boolean;
 }
 
-function ArticlesList({ articles, alwaysShowAllDetails }: ArticlesListProps) {
+const ArticlesList: React.FC<ArticlesListProps> = ({
+  articles,
+  alwaysShowAllDetails
+}) => {
   if (!articles) return null;
 
   const hasOnlyOneArticle = articles.length === 1;
@@ -80,11 +83,11 @@ function ArticlesList({ articles, alwaysShowAllDetails }: ArticlesListProps) {
       })}
     </ArticlesListContainer>
   );
-}
+};
 
 export default ArticlesList;
 
-const ListItem = ({ article, narrow }: ArticlesListItemProps) => {
+const ListItem: React.FC<ArticlesListItemProps> = ({ article, narrow }) => {
   if (!article) return null;
 
   const { gridLayout } = useContext(GridLayoutContext);

--- a/@narative/gatsby-theme-novela/src/sections/author/Author.Articles.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/author/Author.Articles.tsx
@@ -10,7 +10,7 @@ interface AuthorArticlesProps {
   articles: IArticle[];
 }
 
-const AuthorArticles = ({ articles }: AuthorArticlesProps) => {
+const AuthorArticles: React.FC<AuthorArticlesProps> = ({ articles }) => {
   return (
     <AuthorArticlesContainer>
       <ArticlesList articles={articles} alwaysShowAllDetails />

--- a/@narative/gatsby-theme-novela/src/sections/author/Author.Hero.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/author/Author.Hero.tsx
@@ -12,7 +12,7 @@ interface AuthorHeroProps {
   author: IAuthor;
 }
 
-const AuthorHero = ({ author }: AuthorHeroProps) => {
+const AuthorHero: React.FC<AuthorHeroProps> = ({ author }) => {
   return (
     <Hero>
       <HeroImage>

--- a/@narative/gatsby-theme-novela/src/templates/article.template.tsx
+++ b/@narative/gatsby-theme-novela/src/templates/article.template.tsx
@@ -19,7 +19,7 @@ import ArticlesNext from "../sections/article/Article.Next";
 import ArticleSEO from "../sections/article/Article.SEO";
 import ArticleShare from "../sections/article/Article.Share";
 
-import { Template } from "../types";
+import { Template } from "@types";
 
 const siteQuery = graphql`
   {

--- a/@narative/gatsby-theme-novela/src/templates/article.template.tsx
+++ b/@narative/gatsby-theme-novela/src/templates/article.template.tsx
@@ -19,6 +19,8 @@ import ArticlesNext from "../sections/article/Article.Next";
 import ArticleSEO from "../sections/article/Article.SEO";
 import ArticleShare from "../sections/article/Article.Share";
 
+import { Template } from "../types";
+
 const siteQuery = graphql`
   {
     allSite {
@@ -33,7 +35,7 @@ const siteQuery = graphql`
   }
 `;
 
-function Article({ pageContext, location }) {
+const Article: Template = ({ pageContext, location }) => {
   const contentSectionRef = useRef<HTMLElement>(null);
 
   const [hasCalculated, setHasCalculated] = useState<boolean>(false);
@@ -103,7 +105,7 @@ function Article({ pageContext, location }) {
       )}
     </Layout>
   );
-}
+};
 
 export default Article;
 

--- a/@narative/gatsby-theme-novela/src/templates/articles.template.tsx
+++ b/@narative/gatsby-theme-novela/src/templates/articles.template.tsx
@@ -9,7 +9,7 @@ import Paginator from "@components/Navigation/Navigation.Paginator";
 import ArticlesHero from "../sections/articles/Articles.Hero";
 import ArticlesList from "../sections/articles/Articles.List";
 
-import { Template } from "../types";
+import { Template } from "@types";
 
 const ArticlesPage: Template = ({ location, pageContext }) => {
   const articles = pageContext.group;

--- a/@narative/gatsby-theme-novela/src/templates/articles.template.tsx
+++ b/@narative/gatsby-theme-novela/src/templates/articles.template.tsx
@@ -9,7 +9,9 @@ import Paginator from "@components/Navigation/Navigation.Paginator";
 import ArticlesHero from "../sections/articles/Articles.Hero";
 import ArticlesList from "../sections/articles/Articles.List";
 
-function ArticlesPage({ location, pageContext }) {
+import { Template } from "../types";
+
+const ArticlesPage: Template = ({ location, pageContext }) => {
   const articles = pageContext.group;
   const authors = pageContext.additionalContext.authors;
 
@@ -26,7 +28,7 @@ function ArticlesPage({ location, pageContext }) {
       <ArticlesGradient />
     </Layout>
   );
-}
+};
 
 export default ArticlesPage;
 

--- a/@narative/gatsby-theme-novela/src/templates/author.template.tsx
+++ b/@narative/gatsby-theme-novela/src/templates/author.template.tsx
@@ -9,7 +9,7 @@ import Paginator from "@components/Navigation/Navigation.Paginator";
 import AuthorHero from "../sections/author/Author.Hero";
 import AuthorArticles from "../sections/author/Author.Articles";
 
-import { Template } from "../types";
+import { Template } from "@types";
 
 const ArticlesPage: Template = ({ location, pageContext }) => {
   const author = pageContext.additionalContext.author;

--- a/@narative/gatsby-theme-novela/src/templates/author.template.tsx
+++ b/@narative/gatsby-theme-novela/src/templates/author.template.tsx
@@ -9,16 +9,18 @@ import Paginator from "@components/Navigation/Navigation.Paginator";
 import AuthorHero from "../sections/author/Author.Hero";
 import AuthorArticles from "../sections/author/Author.Articles";
 
-function ArticlesPage({ location, pageContext }) {
+import { Template } from "../types";
+
+const ArticlesPage: Template = ({ location, pageContext }) => {
   const author = pageContext.additionalContext.author;
   const articles = pageContext.group;
 
   return (
     <Layout>
-      <SEO 
+      <SEO
         pathname={location.pathname}
         title={author.name}
-        description={author.bio} 
+        description={author.bio}
       />
       <Section narrow>
         <AuthorHero author={author} />

--- a/@narative/gatsby-theme-novela/src/types/index.d.ts
+++ b/@narative/gatsby-theme-novela/src/types/index.d.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import React from "react";
 
 export interface IPaginator {
   pageCount: number;
@@ -66,3 +66,19 @@ export interface IProgress {
   mode: string;
   onClose?: () => void;
 }
+
+export type Icon = React.FC<{
+  fill: string
+}>
+
+// todo : Is anything here optional?
+export type Template = React.FC<{
+  pageContext: {
+    article: IArticle;
+    authors: IAuthor[];
+    // todo : Is this the correct type?
+    mailchimp: boolean;
+    next: IArticle[];
+  };
+  location: Location;
+}>

--- a/@narative/gatsby-theme-novela/src/types/index.d.ts
+++ b/@narative/gatsby-theme-novela/src/types/index.d.ts
@@ -71,12 +71,10 @@ export type Icon = React.FC<{
   fill: string
 }>
 
-// todo : Is anything here optional?
 export type Template = React.FC<{
   pageContext: {
     article: IArticle;
     authors: IAuthor[];
-    // todo : Is this the correct type?
     mailchimp: boolean;
     next: IArticle[];
   };


### PR DESCRIPTION
## What it achieves

- Consistent use of types in component signatures to enable type checking
- Use React's own component types to avoid manually declaring children
  - Fix bug where `Layout` component can't have multiple children (this is my original reason for doing this PR)
  - This sometimes enables the props interface to be completely removed
- Replace one deprecated use of `React.SFC`

## Notes

Requires all function components to be fat arrow/function expressions, because as far as I have been able to find, function declarations only allow the types of the params and return value to be specified, not the function itself.

## Syntactic choices

- `React.FC` could be imported directly as `FC`, making signatures shorter. I chose `React.FC` to stay in line with the one `React.SFC` usage along with a few other `React.[whatever]` usages. Alternatively, it could be `FunctionComponent` or `React.FunctionComponent` to be more explicit.
- I used the explicit `<{}>` for the generic `FC` when there are no props (except `children`), but it's not required; it's to help ensure the function author doesn't forget to declare the props.

## Todo

- [x] Test the changes
- [ ] Make sure the new Template interface is correct
  - [ ] Check if any part of it is optional
  - [ ] Check that `mailchimp` is the right type