### PR TITLE
feat: Generate copyright from content dates

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Footer.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Footer.tsx
@@ -22,12 +22,29 @@ const siteQuery = graphql`
         }
       }
     }
+    allMdx(sort: {fields: frontmatter___date, order: ASC}) {
+      edges {
+        node {
+          frontmatter {
+            date
+          }
+        }
+      }
+    }
   }
 `;
 
 const Footer: React.FC<{}> = () => {
   const results = useStaticQuery(siteQuery);
   const { name, social } = results.allSite.edges[0].node.siteMetadata;
+
+  const copyrightDate = (() => {
+    const { edges } = results.allMdx;
+    const years = [0, edges.length - 1].map((edge) =>
+      new Date(edges[edge].node.frontmatter.date).getFullYear()
+    );
+    return years[0] === years[1] ? `${years[0]}` : `${years[0]}–${years[1]}`;
+  })();
 
   return (
     <>
@@ -36,7 +53,7 @@ const Footer: React.FC<{}> = () => {
         <HoritzontalRule />
         <FooterContainer>
           <FooterText>
-            © {new Date().getFullYear()} {name}
+            © {copyrightDate} {name}
           </FooterText>
           <div>
             <SocialLinks links={social} />


### PR DESCRIPTION
Closes #192 

This generates the copyright dates from the earliest and latest dates in MDX frontmatter.

I couldn't figure out how to add an optional field in `siteMetadata`, but I would still like to add an optional `footer` field to replace the copyright line if the user sets it.