### PR TITLE
Fix references to missing hero image

### DIFF
--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Hero.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Hero.tsx
@@ -17,6 +17,7 @@ interface ArticleHeroProps {
 const ArticleHero: React.FC<ArticleHeroProps> = ({ article, authors }) => {
   const hasCoAUthors = authors.length > 1;
   const hasHeroImage =
+    article.hero &&
     Object.keys(article.hero.full).length !== 0 &&
     article.hero.full.constructor === Object;
 

--- a/@narative/gatsby-theme-novela/src/sections/articles/Articles.List.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/articles/Articles.List.tsx
@@ -1,15 +1,15 @@
-import React, { useContext, useEffect } from "react";
-import styled from "@emotion/styled";
-import { css } from "@emotion/core";
-import { Link } from "gatsby";
+import React, { useContext, useEffect } from 'react';
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+import { Link } from 'gatsby';
 
-import Headings from "@components/Headings";
-import Image, { ImagePlaceholder } from "@components/Image";
+import Headings from '@components/Headings';
+import Image, { ImagePlaceholder } from '@components/Image';
 
-import mediaqueries from "@styles/media";
-import { IArticle } from "@types";
+import mediaqueries from '@styles/media';
+import { IArticle } from '@types';
 
-import { GridLayoutContext } from "./Articles.List.Context";
+import { GridLayoutContext } from './Articles.List.Context';
 
 /**
  * Tiles
@@ -37,12 +37,12 @@ interface ArticlesListItemProps {
 
 const ArticlesList: React.FC<ArticlesListProps> = ({
   articles,
-  alwaysShowAllDetails
+  alwaysShowAllDetails,
 }) => {
   if (!articles) return null;
 
   const hasOnlyOneArticle = articles.length === 1;
-  const { gridLayout = "tiles", hasSetGridLayout, getGridLayout } = useContext(
+  const { gridLayout = 'tiles', hasSetGridLayout, getGridLayout } = useContext(
     GridLayoutContext,
   );
 
@@ -94,7 +94,9 @@ const ListItem: React.FC<ArticlesListItemProps> = ({ article, narrow }) => {
   const hasOverflow = narrow && article.title.length > 35;
   const imageSource = narrow ? article.hero.narrow : article.hero.regular;
   const hasHeroImage =
-    Object.keys(imageSource).length !== 0 && imageSource.constructor === Object;
+    imageSource &&
+    Object.keys(imageSource).length !== 0 &&
+    imageSource.constructor === Object;
 
   return (
     <ArticleLink to={article.slug} data-a11y="false">
@@ -122,8 +124,8 @@ const ListItem: React.FC<ArticlesListItemProps> = ({ article, narrow }) => {
   );
 };
 
-const wide = "1fr";
-const narrow = "457px";
+const wide = '1fr';
+const narrow = '457px';
 
 const limitToTwoLines = css`
   text-overflow: ellipsis;
@@ -232,7 +234,7 @@ const listItemTile = p => css`
 // If only 1 article, dont create 2 rows.
 const listRow = p => css`
   display: grid;
-  grid-template-rows: ${p.hasOnlyOneArticle ? "1fr" : "1fr 1fr"};
+  grid-template-rows: ${p.hasOnlyOneArticle ? '1fr' : '1fr 1fr'};
 `;
 
 const List = styled.div<{
@@ -240,19 +242,19 @@ const List = styled.div<{
   gridLayout: string;
   hasOnlyOneArticle: boolean;
 }>`
-  ${p => (p.gridLayout === "tiles" ? listTile : listRow)}
+  ${p => (p.gridLayout === 'tiles' ? listTile : listRow)}
 `;
 
 const Item = styled.div<{ gridLayout: string }>`
-  ${p => (p.gridLayout === "rows" ? listItemRow : listItemTile)}
+  ${p => (p.gridLayout === 'rows' ? listItemRow : listItemTile)}
 `;
 
 const ImageContainer = styled.div<{ narrow: boolean; gridLayout: string }>`
   position: relative;
-  height: ${p => (p.gridLayout === "tiles" ? "280px" : "220px")};
+  height: ${p => (p.gridLayout === 'tiles' ? '280px' : '220px')};
   box-shadow: 0 30px 60px -10px rgba(0, 0, 0, ${p => (p.narrow ? 0.22 : 0.3)}),
     0 18px 36px -18px rgba(0, 0, 0, ${p => (p.narrow ? 0.25 : 0.33)});
-  margin-bottom: ${p => (p.gridLayout === "tiles" ? "30px" : 0)};
+  margin-bottom: ${p => (p.gridLayout === 'tiles' ? '30px' : 0)};
   transition: transform 0.3s var(--ease-out-quad),
     box-shadow 0.3s var(--ease-out-quad);
 
@@ -278,7 +280,7 @@ const Title = styled(Headings.h2)`
   font-size: 21px;
   font-family: ${p => p.theme.fonts.serif};
   margin-bottom: ${p =>
-    p.hasOverflow && p.gridLayout === "tiles" ? "35px" : "10px"};
+    p.hasOverflow && p.gridLayout === 'tiles' ? '35px' : '10px'};
   transition: color 0.3s ease-in-out;
   ${limitToTwoLines};
 
@@ -307,8 +309,8 @@ const Excerpt = styled.p<{
   font-size: 16px;
   margin-bottom: 10px;
   color: ${p => p.theme.colors.grey};
-  display: ${p => (p.hasOverflow && p.gridLayout === "tiles" ? "none" : "box")};
-  max-width: ${p => (p.narrow ? "415px" : "515px")};
+  display: ${p => (p.hasOverflow && p.gridLayout === 'tiles' ? 'none' : 'box')};
+  max-width: ${p => (p.narrow ? '415px' : '515px')};
 
   ${mediaqueries.desktop`
     display: -webkit-box;
@@ -361,8 +363,8 @@ const ArticleLink = styled(Link)`
     color: ${p => p.theme.colors.accent};
   }
 
-  &[data-a11y="true"]:focus::after {
-    content: "";
+  &[data-a11y='true']:focus::after {
+    content: '';
     position: absolute;
     left: -1.5%;
     top: -2%;


### PR DESCRIPTION
An article's hero image can be undefined sometimes.

Somehow everything works normally when compiled on your machine, but the same code can fail when deploying. For me the issue was deploying on Zeit.

These tweaks fix the problem. I wasn't able to investigate/find a particular root cause, but it seems the theme is designed to work with missing hero images. Fixing the `hasHeroImage` flag to take undefineds into account therefore makes sense as a fix.