### PR TITLE
fix(Navigation.Footer): wrong year

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Footer.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Footer.tsx
@@ -22,7 +22,10 @@ const siteQuery = graphql`
         }
       }
     }
-    allMdx(sort: {fields: frontmatter___date, order: ASC}) {
+    allMdx(
+      sort: { fields: frontmatter___date, order: ASC }
+      filter: { frontmatter: { date: { ne: null } } }
+    ) {
       edges {
         node {
           frontmatter {


### PR DESCRIPTION
## What is this pr about? 👀

The query inside the `Navigation.Footer` was getting all the `MDX` files inside the project which also includes the authors' description. 

I simply add a `filter` in order to exclude the other `.mdx` without date, which will take out the documents we don't want to check.