### PR TITLE
fix: (www/gatsby-config.js) Remove duplicate stackoverflow link in footer

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -32,9 +32,6 @@ const siteMetadata = {
       url: `https://youtube.com`,
     },
     {
-      url: `https://stackoverflow.com`,
-    },
-    {
       name: 'stackoverflow',
       url: `https://bit.ly/1x0885j`,
     },


### PR DESCRIPTION
There were 2 stackoverflow links in the footer. I am unsure why there were 2 links so I am making a pull request with one of them deleted.

They seem to have come in at the commits:
* [A way to manually set the icon for social link #187](https://github.com/narative/gatsby-theme-novela/pull/187)
* [feat: add stackoverflow icon #171](https://github.com/narative/gatsby-theme-novela/pull/171)

The link is also mentioned in Issue #156: [Social Stackoverflow / custom value](https://github.com/narative/gatsby-theme-novela/issues/156) 

I kept the link with the name and url because it was the only link using that syntax in gatsby-config.js


