### PR TITLE
fix: Fix build by changing source to local for www

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -52,8 +52,8 @@ const plugins = [
       authorsPage: true,
       mailchimp: true,
       sources: {
-        local: false,
-        contentful: true,
+        local: true,
+        contentful: false,
       },
     },
   },


### PR DESCRIPTION
Closes #249 

Shouldn't be using a remote data source in CI for the example app imo. Still fails but fails with the error listed here: https://github.com/gatsbyjs/gatsby/issues/15397