### PR TITLE
Fix: Add back defaults to sources

### DIFF
--- a/@narative/gatsby-theme-novela/src/gatsby/node/createPages.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/node/createPages.js
@@ -59,7 +59,7 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
 
   console.log(sources);
   // Defaulting to look at the local MDX files as sources.
-  const { local, contentful } = sources;
+  const { local = true, contentful = false } = sources;
 
   let authors;
   let articles;


### PR DESCRIPTION
Fixes https://github.com/narative/gatsby-theme-novela-example/issues/7

Add back the defaults to sources to maintain original behaviour. Currently both local and contentful are not set by default, causing the default gatsby-config.js to fail. 
