### PR TITLE
Add canonical_url support to articles

### DIFF
--- a/@narative/gatsby-theme-novela/package.json
+++ b/@narative/gatsby-theme-novela/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
+    "@types/react-helmet": "^5.0.15",
     "gatsby": "^2.15.7",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"

--- a/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
@@ -27,7 +27,7 @@ interface HelmetProps {
   pathname: string;
   image?: string;
   url?: string;
-  canonical?: string;
+  canonicalUrl?: string;
   published?: string;
   timeToRead?: string;
 }
@@ -74,8 +74,8 @@ const SEO: React.FC<HelmetProps> = ({
   url,
   image,
   published,
-  pathname,
   timeToRead,
+  canonicalUrl,
 }) => {
   const results = useStaticQuery(seoQuery);
   const site = results.allSite.edges[0].node.siteMetadata;
@@ -100,10 +100,6 @@ const SEO: React.FC<HelmetProps> = ({
     {
       name: 'theme-color',
       content: '#fff',
-    },
-    {
-      rel: 'canonical',
-      href: fullURL(pathname),
     },
     { itemprop: 'name', content: title || site.title },
     { itemprop: 'description', content: description || site.description },
@@ -147,6 +143,7 @@ const SEO: React.FC<HelmetProps> = ({
         href="https://fonts.googleapis.com/css?family=Merriweather:700,700i&display=swap"
         rel="stylesheet"
       />
+      <link rel="canonical" href={canonicalUrl} />
       {children}
     </Helmet>
   );

--- a/@narative/gatsby-theme-novela/src/gatsby/data/data.query.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/data/data.query.js
@@ -29,6 +29,7 @@ module.exports.local = {
           dateForSEO: date
           timeToRead
           excerpt
+          canonical_url
           subscription
           body
           hero {

--- a/@narative/gatsby-theme-novela/src/gatsby/node/createPages.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/node/createPages.js
@@ -214,6 +214,7 @@ module.exports = async ({ actions: { createPage }, graphql }, themeOptions) => {
         slug: article.slug,
         id: article.id,
         title: article.title,
+        canonicalUrl: article.canonical_url,
         mailchimp,
         next,
       },

--- a/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
@@ -93,6 +93,7 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
       ),
       title: node.frontmatter.title,
       subscription: node.frontmatter.subscription !== false,
+      canonical_url: node.frontmatter.canonical_url,
     };
 
     createNode({

--- a/@narative/gatsby-theme-novela/src/gatsby/node/sourceNodes.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/node/sourceNodes.js
@@ -10,6 +10,7 @@ module.exports = ({ actions }) => {
       body: String!
       hero: File @fileByRelativePath
       timeToRead: Int
+      canonical_url: String
     }
   `);
 };

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import React from 'react';
 
-import SEO from "@components/SEO";
+import SEO from '@components/SEO';
 
-import { IArticle, IAuthor } from "@types";
-import { graphql, useStaticQuery } from "gatsby";
+import { IArticle, IAuthor } from '@types';
+import { graphql, useStaticQuery } from 'gatsby';
 
 const siteQuery = graphql`
   {
@@ -36,7 +36,7 @@ const ArticleSEO: React.FC<ArticleSEOProps> = ({
   const siteUrl = results.allSite.edges[0].node.siteMetadata.siteUrl;
 
   const authorsData = authors.map(author => ({
-    "@type": "Person",
+    '@type': 'Person',
     name: author.name,
   }));
 
@@ -67,16 +67,16 @@ const ArticleSEO: React.FC<ArticleSEOProps> = ({
     }
   }
 `.replace(/"[^"]+"|(\s)/gm, function(matched, group1) {
-  if (!group1) {
-    return matched;
-  } else {
-    return "";
-  }
-});
-/**
- * See here for the explanation of the regex above:
- * https://stackoverflow.com/a/23667311
- */
+    if (!group1) {
+      return matched;
+    } else {
+      return '';
+    }
+  });
+  /**
+   * See here for the explanation of the regex above:
+   * https://stackoverflow.com/a/23667311
+   */
 
   return (
     <SEO
@@ -86,6 +86,7 @@ const ArticleSEO: React.FC<ArticleSEOProps> = ({
       timeToRead={article.timeToRead}
       published={article.date}
       pathname={location.href}
+      canonicalUrl={article.canonicalUrl}
     >
       <script type="application/ld+json">{microdata}</script>
     </SEO>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## How to Contribute
+# How to Contribute
 
 ### Setting Up Your Local Dev Environment
 
@@ -32,16 +32,17 @@ We're more than happy with PRs that fix typos, syntax errors, and types. You do 
 
 In order for our publishing workflows with Lerna to properly function, we strictly follow our [.commitlintrc.yml](https://github.com/narative/gatsby-theme-novela/blob/master/.commitlintrc.yml); itself based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/).
 
-Commit should start with a type and the header shouldn't have more than 72 characters. 
+Commit should start with a type and the header shouldn't have more than 72 characters.
 
 ### Possible types
-* `chore`:    Change build process, tooling or dependencies.
-* `ci`:       Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-* `feat`:     Adds a new feature.
-* `fix`:      Solves a bug.
-* `docs`:     Adds or alters documentation.
-* `style`:    Improves formatting, white-space.
-* `refactor`: Rewrites code without feature, performance or bug changes.
-* `perf`:     Improves performance.
-* `test`:     Adds or modifies tests.
-* `revert`:   Changes that reverting other changes
+
+- `chore`: Change build process, tooling or dependencies.
+- `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+- `feat`: Adds a new feature.
+- `fix`: Solves a bug.
+- `docs`: Adds or alters documentation.
+- `style`: Improves formatting, white-space.
+- `refactor`: Rewrites code without feature, performance or bug changes.
+- `perf`: Improves performance.
+- `test`: Adds or modifies tests.
+- `revert`: Changes that reverting other changes

--- a/www/content/posts/2019-04-31-understanding-the-gatsby-lifecycle/index.mdx
+++ b/www/content/posts/2019-04-31-understanding-the-gatsby-lifecycle/index.mdx
@@ -4,6 +4,7 @@ author: Thiago Costa, Dennis Brotzky, Brad Tiller, Mack Mansouri
 date: 2019-04-31
 hero: ./images/hero-2.jpg
 excerpt: With the growing community interest in Gatsby, we hope to create more resources that make it easier for anyone to grasp the power of this incredible tool.
+canonical_url: www.exampleurl.com
 ---
 
 Hello, world! This is a demo post for `gatsby-theme-novela`. Novela is built by the team at [Narative](https://narative.co), and built for everyone that loves the web.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,6 +2481,13 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-helmet@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-5.0.15.tgz#af0370617307e9f062c6aee0f1f5588224ce646e"
+  integrity sha512-CCjqvecDJTXRrHG8aTc2YECcQCl26za/q+NaBRvy/wtm0Uh38koM2dpv2bG1xJV4ckz3t1lm2/5KU6nt2s9BWg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "16.9.17"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.17.tgz#58f0cc0e9ec2425d1441dd7b623421a867aa253e"


### PR DESCRIPTION
## Why?

Canonical Tags are needed when duplicate page content exists across the web. Search Engines use these tags to make sure only the content without the tag will be prioritized. Personally, I use these as I cross-post my content across multiple websites.

reference: https://moz.com/learn/seo/canonicalization

## How?

This package already uses [React Helmet](https://github.com/nfl/react-helmet) so adding the canonical tag can be done easily. Check out the example in the [README](https://github.com/nfl/react-helmet#example) of that package.

These tags must be specified on a per-article basis so a new frontmatter property was created named `canonical_url`. To have this prop be used in the article template, I needed to add it to [how Gatsby creates nodes](https://github.com/narative/gatsby-theme-novela/compare/master...aleccool213:add-canonical-url-support?expand=1#diff-df88a2d045b58d91843cd68243927187R96). Then for Gatsby to be able to query the new prop, I added it to the [custom Article type](https://github.com/narative/gatsby-theme-novela/compare/master...aleccool213:add-canonical-url-support?expand=1#diff-df88a2d045b58d91843cd68243927187R96). From there it was able to be used [when creating pages](https://github.com/narative/gatsby-theme-novela/compare/master...aleccool213:add-canonical-url-support?expand=1#diff-bccd55f85f2eebf7e96c525ff84e25efR217).

My first real pull request to this repo so please tell me if something needs to be changed.

Cheers 🍻 