### PR TITLE
docs: add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,7 @@
 * [ ] New feature (_adding a feature following a feature-request issue_)
 * [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
 * [ ] Refactor (_rewriting existing code without any feature change_)
-
-* [ ] This change is or requires a documentation update
+* [ ] (!) This change is or requires a documentation update
 
 # Description
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,12 +10,12 @@
 
 # Type of PR
 
-- [ ] Bug fix (_non-breaking change which fixes an issue_)
-- [ ] New feature (_adding a feature following a feature-request issue_)
-- [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
-- [ ] Refactor (_rewriting existing code without any feature change_)
+* [ ] Bug fix (_non-breaking change which fixes an issue_)
+* [ ] New feature (_adding a feature following a feature-request issue_)
+* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
+* [ ] Refactor (_rewriting existing code without any feature change_)
 
-- [ ] This change is or requires a documentation update
+* [ ] This change is or requires a documentation update
 
 # Description
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Checklist:
+
+* [ ] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
+* [ ] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
+* [ ] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
+* [ ] I have performed a self-review of my own code.
+* [ ] I have performed the necessary tests locally.
+* [ ] I have linted my code locally prior to submission.
+* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas
+
+# Type of PR
+
+- [ ] Bug fix (_non-breaking change which fixes an issue_)
+- [ ] New feature (_adding a feature following a feature-request issue_)
+- [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
+- [ ] Refactor (_rewriting existing code without any feature change_)
+
+- [ ] This change is or requires a documentation update
+
+# Description
+
+Please include a summary of the change and what is changed by this PR. Please also include relevant motivation and context.
+
+## Additional information/context
+_If relevant, add any information or context that would be useful to evaluate this PR_


### PR DESCRIPTION
Realized we hadn't a PR template so I made one. 

Might create some overhead but I feel it'd help document the PR for the repo and guide new contributors.

Feel free to close it if it's not useful :) 