### PR TITLE
fix: Add slug generator to contentful articles

### DIFF
--- a/@narative/gatsby-theme-novela/src/gatsby/data/data.normalize.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/data/data.normalize.js
@@ -77,6 +77,7 @@ module.exports.contentful = {
     return {
       ...article,
       author,
+      slug: article.fields.slug,
       body: article.body.childMdx.body,
       timeToRead: article.body.childMdx.timeToRead,
     };

--- a/@narative/gatsby-theme-novela/src/gatsby/data/data.query.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/data/data.query.js
@@ -108,6 +108,9 @@ module.exports.contentful = {
           excerpt
           title
           slug
+          fields {
+            slug
+          }
           secret
           date(formatString: "MMMM Do, YYYY")
           dateForSEO: date

--- a/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
@@ -116,6 +116,17 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
     createParentChildLink({ parent: fileNode, child: node });
   }
 
+  if (node.internal.type === `ContentfulArticle`) {
+    createNodeField({
+      node,
+      name: `slug`,
+      value: generateSlug(
+        basePath,
+        generateArticlePermalink(slugify(node.slug || node.title), node.date),
+      ),
+    });
+  }
+
   if (node.internal.type === `ContentfulAuthor`) {
     createNodeField({
       node,


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There is one: #255_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)

# Description

As described in issue #255, Contentful articles were using slug as defined in Contentful, not respecting gatsby-config settings. This fix creates a new slug that is consistent with articles from a local source.

## Additional information/context
N/A
