### PR TITLE
fix: load fonts locally

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-browser.js
+++ b/@narative/gatsby-theme-novela/gatsby-browser.js
@@ -1,3 +1,6 @@
+// Load static fonts
+require('typeface-merriweather');
+
 exports.onInitialClientRender = require('./src/gatsby/browser/onInitialClientRender');
 exports.onRouteUpdate = require('./src/gatsby/browser/onRouteUpdate');
 exports.shouldUpdateScroll = require('./src/gatsby/browser/shouldUpdateScroll');

--- a/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
@@ -139,10 +139,6 @@ const SEO: React.FC<HelmetProps> = ({
       script={themeUIDarkModeWorkaroundScript}
       meta={metaTags}
     >
-      <link
-        href="https://fonts.googleapis.com/css?family=Merriweather:700,700i&display=swap"
-        rel="stylesheet"
-      />
       <link rel="canonical" href={canonicalUrl} />
       {children}
     </Helmet>


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. There isn't one
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [ ] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [x] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

Currently the fonts are loaded via Google Fonts, which are increasing the length of the critical request chains. That can be observed in the PageInsightTool from Google.

In this PR, I'm suggesting to load the fonts locally using the typeface module, already part of the bundle. This way, the RT is way faster and help the speed of the first page load. All the fonts are there, including bold and italic.

BEFORE:
<img width="1278" alt="b1" src="https://user-images.githubusercontent.com/6997921/74608168-84bc1a00-50a4-11ea-943f-f3e812d73a21.png">
<img width="1280" alt="b2" src="https://user-images.githubusercontent.com/6997921/74608169-8685dd80-50a4-11ea-98b7-19ad7637c2ca.png">

AFTER:
<img width="1279" alt="a1" src="https://user-images.githubusercontent.com/6997921/74608162-81289300-50a4-11ea-9db9-8565f603a39b.png">
<img width="1280" alt="a2" src="https://user-images.githubusercontent.com/6997921/74608165-838aed00-50a4-11ea-88d6-f05bfde2b98f.png">
<img width="1280" alt="face" src="https://user-images.githubusercontent.com/6997921/74608170-87b70a80-50a4-11ea-938f-f677ced569cf.png">

NOTE: I'm not entirely sure why the package is part of the bundle and the fonts are still required via `<link>` tag so I might miss something here. Feel free to close it if that doesn't make sense :) 