### PR TITLE
fix: fetch social name for twitter meta tags

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
@@ -41,6 +41,7 @@ const seoQuery = graphql`
             description
             social {
               url
+              name
             }
             siteUrl
             title


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. There isn't one
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

The SEO component renders twitter meta tags in the header. It uses the social data, but doesn't fetch the `name` property which is needed later on to retrieve the twitter specific part.

In this PR, I'm adding the right field to fetch, fixing the `creator` twitter tag.

Before:
<img width="539" alt="before" src="https://user-images.githubusercontent.com/6997921/74697273-cc839400-51bf-11ea-8928-9645fa7096be.png">

After:
<img width="711" alt="after" src="https://user-images.githubusercontent.com/6997921/74697268-ca213a00-51bf-11ea-9d27-5f832d80e7bf.png">
