### PR TITLE
Fix: Hardcoded exports from node_modules

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-node.js
+++ b/@narative/gatsby-theme-novela/gatsby-node.js
@@ -1,7 +1,7 @@
-exports.createPages = require('./src/gatsby/node/createPages');
-exports.createResolvers = require('./src/gatsby/node/createResolvers');
-exports.onCreateNode = require('./src/gatsby/node/onCreateNode');
-exports.onCreateWebpackConfig = require('./src/gatsby/node/onCreateWebpackConfig');
-exports.onPreBootstrap = require('./src/gatsby/node/onPreBootstrap');
-exports.sourceNodes = require('./src/gatsby/node/sourceNodes');
-exports.createSchemaCustomization = require('./src/gatsby/node/createSchemaCustomization');
+exports.createPages = require('@narative/gatsby-theme-novela/src/gatsby/node/createPages');
+exports.createResolvers = require('@narative/gatsby-theme-novela/src/gatsby/node/createResolvers');
+exports.onCreateNode = require('@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode');
+exports.onCreateWebpackConfig = require('@narative/gatsby-theme-novela/src/gatsby/node/onCreateWebpackConfig');
+exports.onPreBootstrap = require('@narative/gatsby-theme-novela/src/gatsby/node/onPreBootstrap');
+exports.sourceNodes = require('@narative/gatsby-theme-novela/src/gatsby/node/sourceNodes');
+exports.createSchemaCustomization = require('@narative/gatsby-theme-novela/src/gatsby/node/createSchemaCustomization');


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #292 
* [x] I have performed a self-review of my own code.
* [ ] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

I had the following issue when adding a new component which requires to pass a context variable: https://github.com/narative/gatsby-theme-novela/issues/292

I was unable to shadow the createPages.js file in the src/gatsby/node folder. I found out that the gatsby-node.js contains hardcoded links for the node exports. This PR should address it so I'm able to shadow the node components in my own repository.

