### PR TITLE
Checks if the source of the image is hosted on Contentful

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
@@ -85,6 +85,13 @@ const SEO: React.FC<HelmetProps> = ({
   const fullURL = (path: string) =>
     path ? `${site.siteUrl}${path}` : site.siteUrl;
 
+  // Checks if the source of the image is hosted on Contentful
+  if(`${image}`.includes('ctfassets')) {
+    image = `https:${image}`;
+  } else {
+    image = fullURL(image);
+  }
+
   // If no image is provided lets looks for a default novela static image
   image = image ? image : '/preview.jpg';
 
@@ -104,7 +111,7 @@ const SEO: React.FC<HelmetProps> = ({
     },
     { itemprop: 'name', content: title || site.title },
     { itemprop: 'description', content: description || site.description },
-    { itemprop: 'image', content: fullURL(image) },
+    { itemprop: 'image', content: image },
     { name: 'description', content: description || site.description },
 
     { name: 'twitter:card', content: 'summary_large_image' },
@@ -114,12 +121,12 @@ const SEO: React.FC<HelmetProps> = ({
     { name: 'twitter:creator', content: twitter.url },
     {
       name: 'twitter:image',
-      content: fullURL(image),
+      content: image,
     },
 
     { property: 'og:title', content: title || site.title },
     { property: 'og:url', content: url },
-    { property: 'og:image', content: fullURL(image) },
+    { property: 'og:image', content: image },
     { property: 'og:description', content: description || site.description },
     { property: 'og:site_name', content: site.name },
   ];


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #308 
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

This is a fix for issue: https://github.com/narative/gatsby-theme-novela/issues/308. When you are using Contentful, the metadata image was populated using your own domain + the image location. Since the images are hosted on https://images.ctfassets.net it returned a faulty url.

## Additional information/context
_If relevant, add any information or context that would be useful to evaluate this PR_
