### PR TITLE
Fix Contentful RSS feed url's

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-config.js
+++ b/@narative/gatsby-theme-novela/gatsby-config.js
@@ -212,6 +212,30 @@ module.exports = ({
               withWebp: true,
             },
           },
+          {
+            resolve: `@raae/gatsby-remark-oembed`,
+            options: {
+              providers: {
+                include: ["Instagram"]
+              }
+            }
+          },
+          {
+            resolve: "gatsby-remark-embed-video",
+            options: {
+              width: 680,
+              ratio: 1.77, // Optional: Defaults to 16/9 = 1.77
+              height: 400, // Optional: Overrides optional.ratio
+              related: false, //Optional: Will remove related videos from the end of an embedded YouTube video.
+              noIframeBorder: true, //Optional: Disable insertion of <style> border: 0
+              urlOverrides: [
+                {
+                  id: 'youtube',
+                  embedURL: (videoId) => `https://www.youtube-nocookie.com/embed/${videoId}`,
+                }
+              ] //Optional: Override URL of a service provider, e.g to enable youtube-nocookie support
+            }
+          },
           { resolve: `gatsby-remark-copy-linked-files` },
           { resolve: `gatsby-remark-numbered-footnotes` },
           { resolve: `gatsby-remark-smartypants` },

--- a/@narative/gatsby-theme-novela/gatsby-config.js
+++ b/@narative/gatsby-theme-novela/gatsby-config.js
@@ -65,7 +65,7 @@ module.exports = ({
                       date: edge.node.date,
                       url: site.siteMetadata.siteUrl + edge.node.slug,
                       guid: site.siteMetadata.siteUrl + edge.node.slug,
-                      // custom_elements: [{ "content:encoded": edge.node.body }],
+                      custom_elements: [{ "content:encoded": edge.node.body }],
                       author: edge.node.author,
                     };
                   });
@@ -77,10 +77,10 @@ module.exports = ({
                       ...edge.node,
                       description: edge.node.excerpt,
                       date: edge.node.date,
-                      url: site.siteMetadata.siteUrl + edge.node.slug,
-                      guid: site.siteMetadata.siteUrl + edge.node.slug,
-                      // custom_elements: [{ "content:encoded": edge.node.body }],
-                      author: edge.node.author,
+                      url: site.siteMetadata.siteUrl + '/' + edge.node.slug,
+                      guid: site.siteMetadata.siteUrl + '/' + edge.node.slug,
+                      custom_elements: [{ "content:encoded": edge.node.body.childMarkdownRemark.html }],
+                      author: edge.node.author ? edge.node.author.name : '',
                     };
                   });
               } else {
@@ -95,7 +95,7 @@ module.exports = ({
                       url: site.siteMetadata.siteUrl + edge.node.slug,
                       guid: site.siteMetadata.siteUrl + edge.node.slug,
                       // custom_elements: [{ "content:encoded": edge.node.body }],
-                      author: edge.node.author,
+                      author: edge.node.author ? edge.node.author.name : '',
                     };
                   });
               }
@@ -107,6 +107,7 @@ module.exports = ({
                 allArticle(sort: {order: DESC, fields: date}) {
                   edges {
                     node {
+                      body
                       excerpt
                       date
                       slug
@@ -128,6 +129,11 @@ module.exports = ({
                       date
                       slug
                       title
+                      body {
+                        childMarkdownRemark {
+                          html
+                        }
+                      }
                       author {
                         name
                       }
@@ -142,6 +148,7 @@ module.exports = ({
                 allArticle(sort: {order: DESC, fields: date}) {
                   edges {
                     node {
+                      body
                       excerpt
                       date
                       slug
@@ -158,6 +165,11 @@ module.exports = ({
                       date
                       slug
                       title
+                      body {
+                        childMarkdownRemark {
+                          html
+                        }
+                      }
                       author {
                         name
                       }
@@ -199,30 +211,6 @@ module.exports = ({
               quality: 80,
               withWebp: true,
             },
-          },
-          {
-            resolve: `@raae/gatsby-remark-oembed`,
-            options: {
-              providers: {
-                include: ["Instagram"]
-              }
-            }
-          },
-          {
-            resolve: "gatsby-remark-embed-video",
-            options: {
-              width: 680,
-              ratio: 1.77, // Optional: Defaults to 16/9 = 1.77
-              height: 400, // Optional: Overrides optional.ratio
-              related: false, //Optional: Will remove related videos from the end of an embedded YouTube video.
-              noIframeBorder: true, //Optional: Disable insertion of <style> border: 0
-              urlOverrides: [
-                {
-                  id: 'youtube',
-                  embedURL: (videoId) => `https://www.youtube-nocookie.com/embed/${videoId}`,
-                }
-              ] //Optional: Override URL of a service provider, e.g to enable youtube-nocookie support
-            }
           },
           { resolve: `gatsby-remark-copy-linked-files` },
           { resolve: `gatsby-remark-numbered-footnotes` },


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

The previous RSS feed was broken for Contentful posts. The url's were missing "/" which meant the links and guids didn't work. I've also enabled the body of the post, so you can have a proper RSS feed and possible integration using medium or dev.to.

## Additional information/context
_If relevant, add any information or context that would be useful to evaluate this PR_
