### PR TITLE
Fixed article SEO img for contentful image source.

### DIFF
--- a/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
@@ -24,12 +24,14 @@ interface ArticleSEOProps {
   article: IArticle;
   authors: IAuthor[];
   location: Location;
+  imagelocation?: string;
 }
 
 const ArticleSEO: React.FC<ArticleSEOProps> = ({
   article,
   authors,
   location,
+  imagelocation,
 }) => {
   const results = useStaticQuery(siteQuery);
   const name = results.allSite.edges[0].node.siteMetadata.name;
@@ -39,6 +41,13 @@ const ArticleSEO: React.FC<ArticleSEOProps> = ({
     '@type': 'Person',
     name: author.name,
   }));
+
+  // Checks if the source of the image is hosted on Contentful
+  if(`${article.hero.seo.src}`.includes('ctfassets')) {
+    imagelocation = `https:${article.hero.seo.src}`;
+  } else {
+    imagelocation = `${siteUrl + article.hero.seo.src}`;
+  }
 
   /**
    * For some reason `location.href` is undefined here when using `yarn build`.
@@ -52,7 +61,7 @@ const ArticleSEO: React.FC<ArticleSEOProps> = ({
       "@id": "${siteUrl + location.pathname}"
     },
     "headline": "${article.title}",
-    "image": "${siteUrl + article.hero.seo.src}",
+    "image": "${imagelocation}",
     "datePublished": "${article.dateForSEO}",
     "dateModified": "${article.dateForSEO}",
     "author": ${JSON.stringify(authorsData)},
@@ -82,7 +91,7 @@ const ArticleSEO: React.FC<ArticleSEOProps> = ({
     <SEO
       title={article.title}
       description={article.excerpt}
-      image={article.hero.seo.src}
+      image={imagelocation}
       timeToRead={article.timeToRead}
       published={article.date}
       pathname={location.href}


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [ ] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

I noticed that the article SEO image url was broken because of the Contentful post. This PR fixes it.

Output of "image" before this fix:
```
{"@context":"https://schema.org","@type":"Article","mainEntityOfPage":{"@type":"WebPage","@id":"https://dannys.space/ready-up-for-the-aws-advanced-networking-exam"},"headline":"Ready up for the AWS Advanced Networking exam","image":"https://dannys.space//images.ctfassets.net/6issw7wxujml/1W1TRZpXoLP9mVR2YLxVh0/51a9f9f2e57f10d165897eccf9cbbf3f/advancednetworkhero.jpg?w=1200&q=100","datePublished":"2020-02-01T13:00+01:00","dateModified":"2020-02-01T13:00+01:00","author":[{"@type":"Person","name":"Danny Steenman"}],"description":"Prepare to read a lot of study material 📚","publisher":{"@type":"Organization","name":"Danny Steenman","logo":{"@type":"ImageObject","url":"https://dannys.space/icons/icon-512x512.png"}}}
```

Output after fix:
```
{"@context":"https://schema.org","@type":"Article","mainEntityOfPage":{"@type":"WebPage","     ":"https://dannys.space/ready-up-for-the-aws-advanced-networking-exam"},"headline":"Ready up for the AWS Advanced Networking exam","image":"https://images.ctfassets.net/6issw7wxujml/1W1TRZpXoLP9mVR2YLxVh0/51a9f9f2e57f10d165897eccf9cbbf3f/advancednetworkhero.jpg?w=1200&q=100","datePublished":"2020-02-01T13:00+01:00","dateModified":"2020-02-01T13:00+01:00","author":[{"@type":"Person","name":"Danny Steenman"}],"description":"Prepare to read a lot of study material 📚","publisher":{"@type":"Organization","name":"Danny Steenman","logo":{"@type":"ImageObject","url":"https://dannys.space/icons/icon-512x512.png"}}}
```