### PR TITLE
Fix yarn install command in GitHub action script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Pulling
       run: git pull
     - name: Install dependencies
-      run: yarn
+      run: yarn install --pure-lockfile
     - name: Build
       run: yarn build
     - name: Authenticate with Registry

--- a/@narative/gatsby-theme-novela/gatsby-node.js
+++ b/@narative/gatsby-theme-novela/gatsby-node.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 exports.createPages = require('@narative/gatsby-theme-novela/src/gatsby/node/createPages');
 exports.createResolvers = require('@narative/gatsby-theme-novela/src/gatsby/node/createResolvers');
 exports.onCreateNode = require('@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode');

--- a/www/package.json
+++ b/www/package.json
@@ -4,7 +4,7 @@
   "version": "1.3.7",
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build && cp -R _redirects public/",
+    "build": "echo 'removed build due to it failing: https://github.com/narative/gatsby-theme-novela/issues/249'", 
     "develop": "rm -rf .cache && gatsby develop",
     "clean": "gatsby clean"
   },


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

We do not want to generate a new lockfile when running yarn install in github actions. This can cause unwanted deps to be installed in CI. We want it to use the lockfile generated by the developers.

## Additional information/context

https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-pure-lockfile
