### PR TITLE
Removed hardcoded "https:" for SEO

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
@@ -87,7 +87,7 @@ const SEO: React.FC<HelmetProps> = ({
 
   // Checks if the source of the image is hosted on Contentful
   if (`${image}`.includes('ctfassets')) {
-    image = `https:${image}`;
+    image = `${image}`;
   } else {
     image = fullURL(image);
   }


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

I saw that contentful updated the image link and added "https:" themselves. So it's not required anymore.