### PR TITLE
Fix: broken CSS in article share menu

### DIFF
--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Share.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Share.tsx
@@ -280,7 +280,7 @@ const MenuFloat = styled.div<{ isDark: boolean }>`
 `;
 
 const MenuText = styled.span`
-  margin-right: 11px;
+  margin-right: 8px;
 `;
 
 const Hidden = styled.div`


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There is one : #319_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)

# Description

This addresses issue #319, fixing a broken CSS element in the article share menu. Simple case of changing the value of the right margin.
