### PR TITLE
Fix og:url and added og:type and og:site_name

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
@@ -72,7 +72,7 @@ const SEO: React.FC<HelmetProps> = ({
   title,
   description,
   children,
-  url,
+  pathname,
   image,
   published,
   timeToRead,
@@ -125,10 +125,11 @@ const SEO: React.FC<HelmetProps> = ({
     },
 
     { property: 'og:title', content: title || site.title },
-    { property: 'og:url', content: url },
+    { property: 'og:url', content: site.siteUrl + pathname },
     { property: 'og:image', content: image },
     { property: 'og:description', content: description || site.description },
-    { property: 'og:site_name', content: site.name },
+    { property: 'og:site_name', content: site.title },
+    { property: 'og:type', content: 'website' },
   ];
 
   if (published) {

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.SEO.tsx
@@ -94,7 +94,7 @@ const ArticleSEO: React.FC<ArticleSEOProps> = ({
       image={imagelocation}
       timeToRead={article.timeToRead}
       published={article.date}
-      pathname={location.href}
+      pathname={location.pathname}
       canonicalUrl={article.canonical_url}
     >
       <script type="application/ld+json">{microdata}</script>


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [ ] I have linted my code locally prior to submission.
* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

The content of the meta og:url was empty (seems like the helmet prop "url" is empty):

```
<meta property="og:url" content="" data-react-helmet="true">
```

With this fix:
```
<meta property="og:url" content="https://dannys.space/ready-up-for-the-aws-advanced-networking-exam" data-react-helmet="true">
```

og:site_name used the wrong property, this is fixed as well. I've added og:type to the mix as well.