### PR TITLE
Fix: generateSlug function to create lowercase and default preview image

### DIFF
--- a/@narative/gatsby-theme-novela/contentful/contentful-export.json
+++ b/@narative/gatsby-theme-novela/contentful/contentful-export.json
@@ -234,6 +234,20 @@
           "omitted": false
         },
         {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "unique": true
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
           "id": "bio",
           "name": "Bio",
           "type": "Symbol",

--- a/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SEO/SEO.tsx
@@ -85,15 +85,15 @@ const SEO: React.FC<HelmetProps> = ({
   const fullURL = (path: string) =>
     path ? `${site.siteUrl}${path}` : site.siteUrl;
 
+  // If no image is provided lets looks for a default novela static image
+  image = image ? image : '/preview.jpg';
+
   // Checks if the source of the image is hosted on Contentful
   if (`${image}`.includes('ctfassets')) {
     image = `${image}`;
   } else {
     image = fullURL(image);
   }
-
-  // If no image is provided lets looks for a default novela static image
-  image = image ? image : '/preview.jpg';
 
   const metaTags = [
     { charset: 'utf-8' },

--- a/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
@@ -42,7 +42,9 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
   }
 
   function generateSlug(...arguments_) {
-    return `/${arguments_.join('/')}`.replace(/\/\/+/g, '/');
+    return `/${arguments_.join('/')}`
+      .toLowerCase()
+      .replace(/\/\/+/g, '/');
   }
 
   // ///////////////////////////////////////////////////////


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. There is one : #309
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [ ] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

A couple of issues reported that the slug of articles etc.. contained uppercase randomly. I updated the generateSlug function to fix this issue. And while I was at it a bug popped it with the meta image (og|twitter) that wouldn't show the preview.jpg because of the order of the statement. So that's fixed as well.
