### PR TITLE
fix: stop showing back button on home page

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Navigation/Navigation.Header.tsx
@@ -97,10 +97,11 @@ const NavigationHeader: React.FC<{}> = () => {
     const prev = localStorage.getItem("previousPath");
     const previousPathWasHomepage =
       prev === (rootPath || basePath) || (prev && prev.includes("/page/"));
-    const isNotPaginated = !location.pathname.includes("/page/");
+    const currentPathIsHomepage =
+      location.pathname === (rootPath || basePath) || location.pathname.includes("/page/");
 
     setShowBackArrow(
-      previousPathWasHomepage && isNotPaginated && width <= phablet,
+      previousPathWasHomepage && !currentPathIsHomepage && width <= phablet,
     );
     setPreviousPath(prev);
   }, []);


### PR DESCRIPTION
# Checklist:
* [X] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [X] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [X] I have checked for an open issue related to this. There isn't one
* [X] I have performed a self-review of my own code.
* [X] I have performed the necessary tests locally.
* [X] I have linted my code locally prior to submission.
* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [X] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description
Found a bug when playing around with this today: On mobile, navigate to page 2 by pressing "Next". Now navigate back to page 1 by pressing "Prev". The navigating header will be the back arrow. Clicking it will take you back to page 2, which makes no sense.