### PR TITLE
fix(blog): default mixed-case slug

### DIFF
--- a/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
@@ -42,9 +42,7 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
   }
 
   function generateSlug(...arguments_) {
-    return `/${arguments_.join('/')}`
-      .toLowerCase()
-      .replace(/\/\/+/g, '/');
+    return `/${arguments_.join('/')}`.replace(/\/\/+/g, '/');
   }
 
   // ///////////////////////////////////////////////////////
@@ -89,7 +87,7 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
       slug: generateSlug(
         basePath,
         generateArticlePermalink(
-          slugify(node.frontmatter.slug || node.frontmatter.title),
+          slugify(node.frontmatter.slug || node.frontmatter.title, {lower: true}),
           node.frontmatter.date,
         ),
       ),

--- a/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
@@ -48,7 +48,7 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
   // ///////////////////////////////////////////////////////
 
   if (node.internal.type === `AuthorsYaml`) {
-    const slug = node.slug ? `/${node.slug}` : slugify(node.name);
+    const slug = node.slug ? `/${node.slug}` : slugify(node.name, {lower: true});
 
     const fieldData = {
       ...node,
@@ -120,7 +120,7 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
     createNodeField({
       node,
       name: `slug`,
-      value: generateSlug(basePath, 'authors', slugify(node.name)),
+      value: generateSlug(basePath, 'authors', slugify(node.name, {lower: true})),
     });
 
     createNodeField({


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

Fixed the default mixed-case slug which causes “Page with redirect” issues in Google search console. Redirects are typically not advisable for SEO (as they can affect search engine indexing issues and adversely affect site loading time). (As per #309)

While keeping the power of `slug` key which overrides the autogenerated `lower case` slug based on the blog title/author's name. (Broken in #326 as per #336)