### PR TITLE
fix: notion icon error due to replace regex not handling .so domain.

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/SocialLinks/SocialLinks.tsx
+++ b/@narative/gatsby-theme-novela/src/components/SocialLinks/SocialLinks.tsx
@@ -35,7 +35,7 @@ const icons = {
 };
 
 const getHostname = url => {
-  return new URL(url.toLowerCase()).hostname.replace(/[.-]|www|com|net|org/g,'').split('.')[0];
+  return new URL(url.toLowerCase()).hostname.replace(/www|com|net|\.so|org|[.-]/g,'').split('.')[0];
 };
 
 const getServicename = url => {


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #356 
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description
Changed the regex in `replace()` of `getHostname()` of `SocialLinks.tsx` to handle notion.so's url.

## Additional information/context
_If relevant, add any information or context that would be useful to evaluate this PR_
