### PR TITLE
fix: remove unprocessed JS content from local articles in RSS

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-config.js
+++ b/@narative/gatsby-theme-novela/gatsby-config.js
@@ -65,7 +65,8 @@ module.exports = ({
                       date: edge.node.date,
                       url: site.siteMetadata.siteUrl + edge.node.slug,
                       guid: site.siteMetadata.siteUrl + edge.node.slug,
-                      custom_elements: [{ "content:encoded": edge.node.body }],
+                      // body is raw JS and MDX; will need to be processed before it can be used
+                      // custom_elements: [{ "content:encoded": edge.node.body }],
                       author: edge.node.author,
                     };
                   });

--- a/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/node/onCreateNode.js
@@ -48,7 +48,11 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
   // ///////////////////////////////////////////////////////
 
   if (node.internal.type === `AuthorsYaml`) {
-    const slug = node.slug ? `/${node.slug}` : slugify(node.name, {lower: true});
+    const slug = node.slug
+      ? `/${node.slug}`
+      : slugify(node.name, {
+          lower: true,
+        });
 
     const fieldData = {
       ...node,
@@ -87,7 +91,9 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
       slug: generateSlug(
         basePath,
         generateArticlePermalink(
-          slugify(node.frontmatter.slug || node.frontmatter.title, {lower: true}),
+          slugify(node.frontmatter.slug || node.frontmatter.title, {
+            lower: true,
+          }),
           node.frontmatter.date,
         ),
       ),
@@ -120,7 +126,13 @@ module.exports = ({ node, actions, getNode, createNodeId }, themeOptions) => {
     createNodeField({
       node,
       name: `slug`,
-      value: generateSlug(basePath, 'authors', slugify(node.name, {lower: true})),
+      value: generateSlug(
+        basePath,
+        'authors',
+        slugify(node.name, {
+          lower: true,
+        }),
+      ),
     });
 
     createNodeField({


### PR DESCRIPTION
# Checklist:

* [X] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [X] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [X] I have checked for an open issue related to this. _There is one : #340_
* [X] I have performed a self-review of my own code.
* [X] I have performed the necessary tests locally.
* [ ] I have linted my code locally prior to submission.
* [X] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [X] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

Raw JS with MDX content is appearing in RSS.xml for local articles. In the original PR, it was decided not to support article content because the author's (and this one) don't know how to process the body. That line was mistakenly uncommented later.

I've added a comment to clarify the reason for the line being commented out.