### PR TITLE
fix for starter and contentful import

### DIFF
--- a/@narative/gatsby-theme-novela/src/gatsby/data/data.query.js
+++ b/@narative/gatsby-theme-novela/src/gatsby/data/data.query.js
@@ -96,7 +96,7 @@ module.exports.local = {
 
 module.exports.contentful = {
   articles: `{
-    articles: allContentfulPost(sort: {fields: [date, title], order: DESC}, limit: 1000) {
+    articles: allContentfulArticle(sort: {fields: [date, title], order: DESC}, limit: 1000) {
       edges {
         node {
           body {


### PR DESCRIPTION
# Checklist:

* [ x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [ x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _**There isn't one** / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [x] (!) This change is or requires a documentation update

# Description

Fixes error in GraphQL query: 'Cannot query field "allContentfulPost" on type "Query".' when using Contentful datasource and the Starter. 

## Additional information/context
Appears to be due to mixing Article & Post terminology. Attempted to resolve within the [contentful-export.json](https://github.com/narative/gatsby-theme-novela/tree/master/%40narative/gatsby-theme-novela/contentful) without success. Renaming query resolved.