### PR TITLE
relative article next links 404, make rooted

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-config.js
+++ b/@narative/gatsby-theme-novela/gatsby-config.js
@@ -54,7 +54,7 @@ module.exports = ({
         },
         feeds: [
           {
-            serialize: ({ query: { site, allArticle, allContentfulPost } }) => {
+            serialize: ({ query: { site, allArticle, allContentfulArticle } }) => {
               if (local && !contentful) {
                 return allArticle.edges
                   .filter(edge => !edge.node.secret)
@@ -71,7 +71,7 @@ module.exports = ({
                     };
                   });
               } else if (!local && contentful) {
-                return allContentfulPost.edges
+                return allContentfulArticle.edges
                   .filter(edge => !edge.node.secret)
                   .map(edge => {
                     return {
@@ -85,7 +85,7 @@ module.exports = ({
                     };
                   });
               } else {
-                const allArticlesData = { ...allArticle, ...allContentfulPost };
+                const allArticlesData = { ...allArticle, ...allContentfulArticle };
                 return allArticlesData.edges
                   .filter(edge => !edge.node.secret)
                   .map(edge => {
@@ -123,7 +123,7 @@ module.exports = ({
                 : !local && contentful
                 ? `
               {
-                allContentfulPost(sort: {order: DESC, fields: date}) {
+                allContentfulArticle(sort: {order: DESC, fields: date}) {
                   edges {
                     node {
                       excerpt
@@ -159,7 +159,7 @@ module.exports = ({
                     }
                   }
                 }
-                allContentfulPost(sort: {order: DESC, fields: date}) {
+                allContentfulArticle(sort: {order: DESC, fields: date}) {
                   edges {
                     node {
                       excerpt

--- a/@narative/gatsby-theme-novela/src/sections/article/Article.Next.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/article/Article.Next.tsx
@@ -52,7 +52,7 @@ const GridItem: React.FC<GridItemProps> = ({ article, narrow }) => {
 
   return (
     <ArticleLink
-      to={article.slug}
+      to={"/"+article.slug}
       data-a11y="false"
       narrow={narrow ? "true" : "false"}
     >

--- a/@narative/gatsby-theme-novela/src/sections/articles/Articles.List.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/articles/Articles.List.tsx
@@ -99,7 +99,7 @@ const ListItem: React.FC<ArticlesListItemProps> = ({ article, narrow }) => {
     imageSource.constructor === Object;
 
   return (
-    <ArticleLink to={article.slug} data-a11y="false">
+    <ArticleLink to={"/"+article.slug} data-a11y="false">
       <Item gridLayout={gridLayout}>
         <ImageContainer narrow={narrow} gridLayout={gridLayout}>
           {hasHeroImage ? <Image src={imageSource} /> : <ImagePlaceholder />}


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

Next article links are relative to current page and throw 404. Concatenated forward slash to article slug to root them.

## Additional information/context
`<ArticleLink
      to={"/"+article.slug}
      data-a11y="false"
      narrow={narrow ? "true" : "false"}
    >`
