### PR TITLE
fix: Render bio as HTML on Author's page

### DIFF
--- a/@narative/gatsby-theme-novela/src/sections/author/Author.Hero.tsx
+++ b/@narative/gatsby-theme-novela/src/sections/author/Author.Hero.tsx
@@ -19,7 +19,7 @@ const AuthorHero: React.FC<AuthorHeroProps> = ({ author }) => {
         <RoundedImage src={author.avatar.large} />
       </HeroImage>
       <Heading>{author.name}</Heading>
-      <Subheading>{author.bio}</Subheading>
+      <Subheading dangerouslySetInnerHTML={{__html: author.bio}}></Subheading>
       <Social>
         <SocialLinks links={author.social} />
       </Social>


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. There is one : #372
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description
Fixed a bug where the bio of the author is displayed as text on Author's page. Please see the #372 issue description.

