### PR TITLE
feat: Added ability to implement a custom article footer

### DIFF
--- a/@narative/gatsby-theme-novela/src/templates/article.footer.template.tsx
+++ b/@narative/gatsby-theme-novela/src/templates/article.footer.template.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import Subscription from "@components/Subscription";
+
+import { Template } from "@types";
+
+
+const ArticleFooter: Template = ({ pageContext }) => {
+  const { article, mailchimp } = pageContext;
+
+  return (
+    <>
+      {mailchimp && article.subscription && <Subscription />}
+    </>
+  );
+};
+
+export default ArticleFooter;

--- a/@narative/gatsby-theme-novela/src/templates/article.template.tsx
+++ b/@narative/gatsby-theme-novela/src/templates/article.template.tsx
@@ -18,6 +18,7 @@ import ArticleControls from "../sections/article/Article.Controls";
 import ArticlesNext from "../sections/article/Article.Next";
 import ArticleSEO from "../sections/article/Article.SEO";
 import ArticleShare from "../sections/article/Article.Share";
+import ArticleFooter from './article.footer.template';
 
 import { Template } from "@types";
 
@@ -44,7 +45,7 @@ const Article: Template = ({ pageContext, location }) => {
   const results = useStaticQuery(siteQuery);
   const name = results.allSite.edges[0].node.siteMetadata.name;
 
-  const { article, authors, mailchimp, next } = pageContext;
+  const { article, authors, next } = pageContext;
 
   useEffect(() => {
     const calculateBodySize = throttle(() => {
@@ -95,7 +96,7 @@ const Article: Template = ({ pageContext, location }) => {
           <ArticleShare />
         </MDXRenderer>
       </ArticleBody>
-      {mailchimp && article.subscription && <Subscription />}
+      <ArticleFooter pageContext={pageContext} />
       {next.length > 0 && (
         <NextArticle narrow>
           <FooterNext>More articles from {name}</FooterNext>


### PR DESCRIPTION
# Checklist:

* [X] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [X] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [X] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [X] I have performed a self-review of my own code.
* [X] I have performed the necessary tests locally.
* [X] I have linted my code locally prior to submission.
* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [ ] Bug fix (_non-breaking change which fixes an issue_)
* [X] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

This PR pulls out the Mailchimp subscription box into its own component, allowing us to easily use the existing component shadowing to attach footers to every post without modifying the entire article template.
