### PR TITLE
Make all Contentful fields required

### DIFF
--- a/@narative/gatsby-theme-novela/contentful/contentful-export.json
+++ b/@narative/gatsby-theme-novela/contentful/contentful-export.json
@@ -56,7 +56,7 @@
           "name": "Secret",
           "type": "Boolean",
           "localized": false,
-          "required": false,
+          "required": true,
           "validations": [
           ],
           "disabled": false,
@@ -117,7 +117,7 @@
           "name": "Date",
           "type": "Date",
           "localized": false,
-          "required": false,
+          "required": true,
           "validations": [
           ],
           "disabled": false,
@@ -252,7 +252,7 @@
           "name": "Bio",
           "type": "Symbol",
           "localized": false,
-          "required": false,
+          "required": true,
           "validations": [
           ],
           "disabled": false,
@@ -280,7 +280,7 @@
           "name": "Featured",
           "type": "Boolean",
           "localized": false,
-          "required": false,
+          "required": true,
           "validations": [
           ],
           "disabled": false,
@@ -291,7 +291,7 @@
           "name": "Social",
           "type": "Array",
           "localized": false,
-          "required": false,
+          "required": true,
           "validations": [
           ],
           "disabled": false,


### PR DESCRIPTION
# Checklist:

* [X] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [X] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [X] I have checked for an open issue related to this. _There isn't one_
* [X] I have performed a self-review of my own code.
* [X] I have performed the necessary tests locally.
* [X] I have linted my code locally prior to submission.
* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [X] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

Contentful throws errors when using non-required fields for content models. Setting `required` to `true` when importing the content models into Contentful resolves all errors.

## Additional information/context
Errors are listed below:

```
ERROR #85923  GRAPHQL

There was an error in your GraphQL query:

Cannot query field "secret" on type "ContentfulArticle".

If you don't expect "secret" to exist on the type "ContentfulArticle" it is most likely a typo.
However, if you expect "secret" to exist there are a couple of solutions to common problems:

- If you added a new data source and/or changed something inside gatsby-node.js/gatsby-config.js, please try a restart of your development server
- The field might be accessible in another subfield, please try your query in GraphiQL and use the GraphiQL explorer to see which fields you can query and what shape they have
- You want to optionally use your field "secret" and right now it is not used anywhere. Therefore Gatsby can't infer the type and add it to the GraphQL schema. A quick fix is to add at least one entry with that field ("dummy content")

It is recommended to explicitly type your GraphQL schema if you want to use optional fields. This way you don't have to add the mentioned "dummy content". Visit our docs to learn how you can define the schema for "ContentfulArticle":
https://www.gatsbyjs.org/docs/schema-customization/#creating-type-definitions

File: node_modules/@narative/gatsby-theme-novela/src/gatsby/node/createPages.js:114:40
```

```
ERROR #85923  GRAPHQL

There was an error in your GraphQL query:

Cannot query field "date" on type "ContentfulArticle".

If you don't expect "date" to exist on the type "ContentfulArticle" it is most likely a typo.
However, if you expect "date" to exist there are a couple of solutions to common problems:

- If you added a new data source and/or changed something inside gatsby-node.js/gatsby-config.js, please try a restart of your development server
- The field might be accessible in another subfield, please try your query in GraphiQL and use the GraphiQL explorer to see which fields you can query and what shape they have
- You want to optionally use your field "date" and right now it is not used anywhere. Therefore Gatsby can't infer the type and add it to the GraphQL schema. A quick fix is to add at least one entry with that field ("dummy content")

It is recommended to explicitly type your GraphQL schema if you want to use optional fields. This way you don't have to add the mentioned "dummy content". Visit our docs to learn how you can define the schema for "ContentfulArticle":
https://www.gatsbyjs.org/docs/schema-customization/#creating-type-definitions

File: node_modules/@narative/gatsby-theme-novela/src/gatsby/node/createPages.js:114:40
```

```
ERROR #85923  GRAPHQL

There was an error in your GraphQL query:

Cannot query field "featured" on type "ContentfulAuthor".

If you don't expect "featured" to exist on the type "ContentfulAuthor" it is most likely a typo.
However, if you expect "featured" to exist there are a couple of solutions to common problems:

- If you added a new data source and/or changed something inside gatsby-node.js/gatsby-config.js, please try a restart of your development server
- The field might be accessible in another subfield, please try your query in GraphiQL and use the GraphiQL explorer to see which fields you can query and what shape they have
- You want to optionally use your field "featured" and right now it is not used anywhere. Therefore Gatsby can't infer the type and add it to the GraphQL schema. A quick fix is to add at least one entry with that field ("dummy content")

It is recommended to explicitly type your GraphQL schema if you want to use optional fields. This way you don't have to add the mentioned "dummy content". Visit our docs to learn how you can define the schema for "ContentfulAuthor":
https://www.gatsbyjs.org/docs/schema-customization/#creating-type-definitions

File: node_modules/@narative/gatsby-theme-novela/src/gatsby/node/createPages.js:113:39
```

```
ERROR #85923  GRAPHQL

There was an error in your GraphQL query:

Cannot query field "bio" on type "ContentfulAuthor".

If you don't expect "bio" to exist on the type "ContentfulAuthor" it is most likely a typo.
However, if you expect "bio" to exist there are a couple of solutions to common problems:

- If you added a new data source and/or changed something inside gatsby-node.js/gatsby-config.js, please try a restart of your development server
- The field might be accessible in another subfield, please try your query in GraphiQL and use the GraphiQL explorer to see which fields you can query and what shape they have
- You want to optionally use your field "bio" and right now it is not used anywhere. Therefore Gatsby can't infer the type and add it to the GraphQL schema. A quick fix is to add at least one entry with that field ("dummy content")

It is recommended to explicitly type your GraphQL schema if you want to use optional fields. This way you don't have to add the mentioned "dummy content". Visit our docs to learn how you can define the schema for "ContentfulAuthor":
https://www.gatsbyjs.org/docs/schema-customization/#creating-type-definitions

File: node_modules/@narative/gatsby-theme-novela/src/gatsby/node/createPages.js:113:39
```

```
ERROR #85923  GRAPHQL

There was an error in your GraphQL query:

Cannot query field "social" on type "ContentfulAuthor".

If you don't expect "social" to exist on the type "ContentfulAuthor" it is most likely a typo.
However, if you expect "social" to exist there are a couple of solutions to common problems:

- If you added a new data source and/or changed something inside gatsby-node.js/gatsby-config.js, please try a restart of your development server
- The field might be accessible in another subfield, please try your query in GraphiQL and use the GraphiQL explorer to see which fields you can query and what shape they have
- You want to optionally use your field "social" and right now it is not used anywhere. Therefore Gatsby can't infer the type and add it to the GraphQL schema. A quick fix is to add at least one entry with that field ("dummy content")

It is recommended to explicitly type your GraphQL schema if you want to use optional fields. This way you don't have to add the mentioned "dummy content". Visit our docs to learn how you can define the schema for "ContentfulAuthor":
https://www.gatsbyjs.org/docs/schema-customization/#creating-type-definitions

File: node_modules/@narative/gatsby-theme-novela/src/gatsby/node/createPages.js:113:39
```