### PR TITLE
fix: Long words, text, or URL links could break the article layout (small resolutions)

### DIFF
--- a/@narative/gatsby-theme-novela/src/styles/global.ts
+++ b/@narative/gatsby-theme-novela/src/styles/global.ts
@@ -40,6 +40,7 @@ export const globalStyles = css`
     text-rendering: optimizeLegibility;
     cursor: default;
     font-size: 0.625rem;
+    line-break: anywhere;
     line-height: 1.4;
   }
 


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [ ] I have performed the necessary tests locally.
* [ ] I have linted my code locally prior to submission.
* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bugfix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

Hey there, I published my first article using this theme and I have detected that this theme is not using the `line-break` CSS property; if we are not using it, all long words, text, or URL links can break the layout.

## Additional information/context
Maybe my comments above are not so clear, but screen captures can help.

This is my blog article where you can replicate the issue:
https://josejesus.dev/Crea-tu-propio-grid-system

At the end of my article, I added two links:

![image](https://user-images.githubusercontent.com/8441759/96407863-f30f2a00-11a7-11eb-8fcf-6e49bf6be332.png)

You can resize the browser window in small resolutions to confirm how long words/text can break the article layout.

![image](https://user-images.githubusercontent.com/8441759/96407975-2e115d80-11a8-11eb-9506-4cf522a10ca4.png)

It could be solved easily with the `line-break: anywhere` rule in the `:root` element.

![image](https://user-images.githubusercontent.com/8441759/96408270-c4de1a00-11a8-11eb-8b75-f250779831aa.png)

