### PR TITLE
fix: word-break inside TableCell

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/Tables/Table.Cell.tsx
+++ b/@narative/gatsby-theme-novela/src/components/Tables/Table.Cell.tsx
@@ -4,6 +4,7 @@ import mediaqueries from "@styles/media";
 const Cell = styled.td`
   border-top: 1px solid ${p => p.theme.colors.horizontalRule};
   padding: 15px 30px;
+  word-break: keep-all;
   font-size: 16px;
   background: ${p => p.theme.colors.card};
 


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

When using a Markdown table which contains wide Images, the text tags are being pushed and start to break apart, making them almost unreadable ...

## Additional information/context

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3399429/97231486-cd070c80-17db-11eb-899c-3d35479a3307.png) | ![image](https://user-images.githubusercontent.com/3399429/97231460-c4aed180-17db-11eb-82cd-8236aee467fa.png) |
