### PR TITLE
Fix breaking line-break change

### DIFF
--- a/@narative/gatsby-theme-novela/src/styles/global.ts
+++ b/@narative/gatsby-theme-novela/src/styles/global.ts
@@ -40,7 +40,6 @@ export const globalStyles = css`
     text-rendering: optimizeLegibility;
     cursor: default;
     font-size: 0.625rem;
-    line-break: anywhere;
     line-height: 1.4;
   }
 


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)

# Description

Hi there, this pull request addresses an issue introduced by pull request #431. The merge added a global `line-break` change which allowed line breaks to be introduced anywhere. 

I believe the intention was to allow URLs to adjust their line breaks as dimensions changed, but because it was applied globally, it negatively impacts other areas such as the hero text, author bio, and date within the article. See below as an example:

<img width="1680" alt="Screenshot 2020-10-29 at 12 07 23" src="https://user-images.githubusercontent.com/33377034/97561735-e3ca8080-19e0-11eb-93e1-227099aa0c9a.png">

## Additional information/context

This is what the above image looks like with the removal of the erroneous `line-break` change:

<img width="1680" alt="Screenshot 2020-10-29 at 12 19 24" src="https://user-images.githubusercontent.com/33377034/97561831-08265d00-19e1-11eb-82bf-3ef80a224747.png">