### PR TITLE
style: add semicolon for have uniformity

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/Layout/index.ts
+++ b/@narative/gatsby-theme-novela/src/components/Layout/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Layout'
+export { default } from './Layout';

--- a/@narative/gatsby-theme-novela/src/components/Logo/index.ts
+++ b/@narative/gatsby-theme-novela/src/components/Logo/index.ts
@@ -1,1 +1,1 @@
-export { default } from '@components/Logo/Logo'
+export { default } from '@components/Logo/Logo';

--- a/@narative/gatsby-theme-novela/src/components/Navigation/index.ts
+++ b/@narative/gatsby-theme-novela/src/components/Navigation/index.ts
@@ -1,1 +1,1 @@
-export { default } from '@components/Navigation/Navigation.Header'
+export { default } from '@components/Navigation/Navigation.Header';

--- a/@narative/gatsby-theme-novela/src/components/Progress/index.ts
+++ b/@narative/gatsby-theme-novela/src/components/Progress/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Progress'
+export { default } from './Progress';

--- a/@narative/gatsby-theme-novela/src/components/SEO/index.ts
+++ b/@narative/gatsby-theme-novela/src/components/SEO/index.ts
@@ -1,1 +1,1 @@
-export { default } from '@components/SEO/SEO'
+export { default } from '@components/SEO/SEO';

--- a/@narative/gatsby-theme-novela/src/components/Section/index.ts
+++ b/@narative/gatsby-theme-novela/src/components/Section/index.ts
@@ -1,1 +1,1 @@
-export { default } from '@components/Section/Section'
+export { default } from '@components/Section/Section';


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [ ] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [ ] I have performed the necessary tests locally.
* [ ] I have linted my code locally prior to submission.
* [ ] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [ ] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [x] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

I think there hasn't uniformity for semicolon.

TypeScript can work `export { default } from 'XXXX'` without semicolon.
But other codes are with semicolon, so better with semicolon for uniformity .

## Additional information/context

I tried to run local, but error occupy.
-> before I try to edit codes

`Setting Up Your Local Dev Environment` in CONTRIBUTING.md has wrong process?
error was related for Contentful.