### PR TITLE
fix: update gatsby-plugin-emotion option

### DIFF
--- a/@narative/gatsby-theme-novela/gatsby-config.js
+++ b/@narative/gatsby-theme-novela/gatsby-config.js
@@ -254,7 +254,7 @@ module.exports = ({
     {
       resolve: `gatsby-plugin-emotion`,
       options: {
-        displayName: process.env.NODE_ENV === `development`,
+        autoLabel: process.env.NODE_ENV === `development`,
       },
     },
   ],


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #442
* [x] I have performed a self-review of my own code.
* [ ] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

Formerly, the emotion gatsby plugin was using an unrecognized option name. It should be `autoLabel` instead of `displayName`.
