### PR TITLE
Fix horizontal scrollbar from appearing when using .Image__Large.

### DIFF
--- a/@narative/gatsby-theme-novela/src/components/MDX/MDX.tsx
+++ b/@narative/gatsby-theme-novela/src/components/MDX/MDX.tsx
@@ -69,7 +69,7 @@ export default MDX;
 const IMAGE_WIDTHS = {
   regular: '680px',
   large: '1004px',
-  full: '100vw',
+  full: '100%',
 };
 
 const ARTICLE_WIDTH = css`
@@ -295,7 +295,7 @@ const ImageCSS = css`
   div.Image__Large {
     position: relative;
     left: -68px;
-    width: ${IMAGE_WIDTHS.full};
+    width: calc(${IMAGE_WIDTHS.full} + 68px);
     margin: 25px auto 60px;
     pointer-events: none;
 
@@ -310,11 +310,13 @@ const ImageCSS = css`
 
     ${mediaqueries.desktop`
       left: -53px;
+      width: calc(${IMAGE_WIDTHS.full} + 53px);
     `};
 
     ${mediaqueries.tablet`
       left: 0;
       margin: 0 auto 25px;
+      width: ${IMAGE_WIDTHS.full};
     `};
   }
 `;


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

Fixes the horizontal scrollbar from appearing when using `.Image__Large`. Bug can be seen on [this post in your demo](https://novela.narative.co/Understanding-the-Gatsby-lifecycle-with-Narative).

## Additional information/context
_If relevant, add any information or context that would be useful to evaluate this PR_
