### PR TITLE
chore: update theme-ui to 0.3.5 from 0.2.40

### DIFF
--- a/@narative/gatsby-theme-novela/README.md
+++ b/@narative/gatsby-theme-novela/README.md
@@ -365,7 +365,7 @@ import novelaTheme from '@narative/gatsby-theme-novela/src/gatsby-plugin-theme-u
 
 export default {
   ...novelaTheme,
-  initialColorMode: `dark`,
+  initialColorModeName: `dark`,
   colors: {
     ...novelaTheme.colors,
     primary: '#000',

--- a/@narative/gatsby-theme-novela/package.json
+++ b/@narative/gatsby-theme-novela/package.json
@@ -40,7 +40,6 @@
     "@emotion/core": "^10.0.14",
     "@emotion/styled": "^10.0.14",
     "@mdx-js/mdx": "^1.1.0",
-    "@mdx-js/react": "^1.0.27",
     "@raae/gatsby-remark-oembed": "^0.1.1",
     "adm-zip": "^0.4.13",
     "babel-plugin-emotion": "^10.0.14",
@@ -54,7 +53,7 @@
     "gatsby-plugin-mdx": "^1.0.32",
     "gatsby-plugin-react-helmet": "^3.1.2",
     "gatsby-plugin-sharp": "^2.2.9",
-    "gatsby-plugin-theme-ui": "^0.2.40",
+    "gatsby-plugin-theme-ui": "^0.3.5",
     "gatsby-plugin-typescript": "^2.1.2",
     "gatsby-remark-autolink-headers": "^2.1.3",
     "gatsby-remark-check-links": "^1.1.5",
@@ -79,7 +78,7 @@
     "remark-slug": "^5.1.2",
     "request": "^2.88.0",
     "slugify": "^1.3.6",
-    "theme-ui": "^0.2.40",
+    "theme-ui": "^0.3.5",
     "typeface-merriweather": "^0.0.72"
   }
 }

--- a/@narative/gatsby-theme-novela/src/gatsby-plugin-theme-ui/index.ts
+++ b/@narative/gatsby-theme-novela/src/gatsby-plugin-theme-ui/index.ts
@@ -24,7 +24,7 @@ const colorModeTransition =
   'background 0.25s var(--ease-in-out-quad), color 0.25s var(--ease-in-out-quad)';
 
 export default merge({
-  initialColorMode: 'light',
+  initialColorModeName: 'light',
   useCustomProperties: true,
   colorModeTransition,
   colors,

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ import novelaTheme from '@narative/gatsby-theme-novela/src/gatsby-plugin-theme-u
 
 export default {
   ...novelaTheme,
-  initialColorMode: `dark`,
+  initialColorModeName: `dark`,
   colors: {
     ...novelaTheme.colors,
     primary: '#000',


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There is one : #312_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [x] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [ ] (!) This change is or requires a documentation update

# Description

Please include a summary of the change and what is changed by this PR. Please also include relevant motivation and context.

Migrated to latest theme-ui version 0.3.5 as requested by issue #312.

## Additional information/context
_If relevant, add any information or context that would be useful to evaluate this PR_
