### PR TITLE
docs: Fixed author structure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,10 @@ The recommended project structure for your content and site looks like this:
   novela-site
     ├── content
     │ ├── authors
-    │ │   ├── avatars
-    │ │   │    └── avatar.jpg
-    │ │   └── authors.yml
+    │ │   └── authors 
+    │ │       ├── avatars
+    │ │       │    └── avatar.jpg
+    │ │       └── authorname.yml
     │ └── posts
     │     └── 2020-01-01-my-first-novela-post
     │         ├── images
@@ -167,37 +168,38 @@ Once you've setup `@narative/gatsby-theme-novela` plugin in `gatsby-config.js` y
 
 ### Step 4: Adding an Author
 
-In [step 2](#step-2-folder-structure) we created the folder structure of our project. We can now add an Author by populating `/content/authors/authors.yml`:
+In [step 2](#step-2-folder-structure) we created the folder structure of our project. We can now add an Author by populating `/content/authors/authors`:
 
 ```
   novela-site
   └── content
     └── authors
-        ├── avatars
-        │    └── brotzky-avatar.jpg
-        └── authors.yml
+        └── authors 
+            ├── avatars
+            │   └── brotzky-avatar.jpg
+            └── david-brotzky.yml
 ```
 
-In `authors.yml` add an Author. There **must** be at least one `featured` Author.
+In `/content/authors/` add an Author by creating a `authorname.yml` file. There **must** be at least one `featured` Author.
 
-`/content/authors/authors.yml`:
+`/content/authors/authors/david-brotzky.yml`:
 
 ```yml
-- name: Dennis Brotzky
-  bio: |
-    Written by Dennis Brotzky who lives and works in Vancouver building useful things.
-    You should follow him on Twitter.
-  avatar: ./avatars/brotzky-avatar.jpg
-  featured: true
-  social:
-    - url: https://unsplash.com
-    - url: https://stackoverflow.com
-    - url: https://github.com
+name: Dennis Brotzky
+bio: |
+  Written by Dennis Brotzky who lives and works in Vancouver building useful things.
+  You should follow him on Twitter.
+avatar: ./avatars/brotzky-avatar.jpg
+featured: true
+social:
+  - url: https://unsplash.com
+  - url: https://stackoverflow.com
+  - url: https://github.com
 ```
 
 ### Step 5: Adding a Post
 
-Once you have at least one Author defined in `authors.yml` you can add your first Post.
+Once you have at least one Author created, you can add your first Post.
 
 Start by creating a new folder in `content/posts`. You can name it anything you like but we recommend including the date at the front to organize your posts. Once you've created your folder you can add an `index.mdx` file and an `images` folder.
 
@@ -222,6 +224,8 @@ excerpt: This is a love story about Narative and Gatsby
 In order to configure the theme to properly generate the pages and meta tags you must add specific data to `siteMetadata`.
 
 The fields that are unique to Novela are `hero.heading`, `hero.maxWidth`, and `social`.
+
+The complete list of supported names and icons for the `social` field can be found [here](https://github.com/narative/gatsby-theme-novela/blob/master/%40narative/gatsby-theme-novela/src/components/SocialLinks/SocialLinks.tsx#L15).
 
 Add your Site Metadata to the `gatsby-config.js` file.
 


### PR DESCRIPTION
# Checklist:

* [x] I have followed the guidelines in our [Contributing Guidelines](https://github.com/narative/gatsby-theme-novela/blob/master/CONTRIBUTING.md). _Especially our commitlint_
* [x] I have checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/fix/change.
* [x] I have checked for an open issue related to this. _There isn't one / There is one : #XXX_
* [x] I have performed a self-review of my own code.
* [x] I have performed the necessary tests locally.
* [x] I have linted my code locally prior to submission.
* [x] If applicable, I have commented my code, particularly in hard-to-understand areas

# Type of PR

* [ ] Bug fix (_non-breaking change which fixes an issue_)
* [ ] New feature (_adding a feature following a feature-request issue_)
* [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
* [ ] Refactor (_rewriting existing code without any feature change_)
* [x] (!) This change is or requires a documentation update

# Description

While creating my own site with the Novela theme, I realized the documentation in the README, and other docs online, are no longer true. It seems there is no longer an `authors.yml` and the path to individual author files is now `content/authors/authors/authorname.yml`.

I'm not entirely sure if the new author path is a bug or not, but this PR updates the documentation to correctly describe the process of creating an author. 

## Additional information/context
_If relevant, add any information or context that would be useful to evaluate this PR_
